### PR TITLE
Fix chromosome column in find-insertions output

### DIFF
--- a/notes/potential_issues_2026-06-16.md
+++ b/notes/potential_issues_2026-06-16.md
@@ -1,0 +1,348 @@
+# Potential RelocaTE3 issues noticed while building the real-rice validation pipeline
+
+Date: 2026-06-16
+Context: Discovered while implementing `validation/real_rice/` (a reproducible
+regression test that compares RelocaTE3 output to a frozen RelocaTE2 run on
+the same 10 rice samples). None of the items below were the cause of the
+validation-script failures we hit during that work — those were pipeline-
+script bugs (sbatch cwd handling, pixi env hand-off to compute nodes). The
+items here are RelocaTE3 issues to consider fixing in a future session.
+
+---
+
+## 1. `src/RelocaTE3/cli.py` and parts of `src/RelocaTE3/pipeline.py` are dead code
+
+**Symptom.** `cli.py` registers subcommands (`run`, `find-insertions`,
+`find-reference`, `characterize`) with a *different* CLI shape than what
+the installed `relocaTE3` binary actually exposes. For example, `cli.py`'s
+`run` advertises `--sample`, `--te`, `--genome`, `--repeatmasker`,
+`--genotype`, `--len-cut-match`, `--len-cut-trim` and runs the entire
+pipeline including reference-TE filtering and characterization. The real
+binary (entry point goes through `src/RelocaTE3/__main__.py`) uses
+`-n/--name`, `-T/--te-library`, `--min-match`, `--min-trimmed`,
+`--mismatch`, etc., and `run` only chains map + trim — not align-genome
+or find-insertions.
+
+**Evidence.**
+- `pyproject.toml` console script points at `RelocaTE3.__main__:main`, not
+  `RelocaTE3.cli:main`.
+- `pixi run python -c "from RelocaTE3 import cli; ..."` resolves to
+  `src/RelocaTE3/cli.py`, but `relocaTE3 --help` shows the `__main__.py`
+  subcommand set (`map`, `trim`, `run`, `annotate-ref`, `index-genome`,
+  `align-genome`, `find-insertions`, `characterize`).
+- `src/RelocaTE3/pipeline.py` imports `find_insertions`, `read_insertions_gff`,
+  `write_insertions_gff`, `find_reference_insertions`,
+  `write_existing_te_bed_from_rm`, `read_read_repeat`,
+  `characterize_insertions`, `write_characterized` — those names don't exist
+  in the current `insertions.py` / `reference_te.py` / `characterize.py` / 
+  `genome_align.py` modules (which define `InsertionFinder`,
+  `ReferenceTEAnnotator`, `Characterizer` instead).
+
+**Why this matters.** Anyone reading the source to wire RelocaTE3 into a
+new workflow (as I did to build the validation script) will read `cli.py`
+first and infer the wrong API. It cost me an iteration in the validation
+pipeline because I wrote `relocaTE3 run --sample ... --te ... --genome ...`
+based on `cli.py`.
+
+**Suggested fix.** Either delete `cli.py` and the now-unreachable
+`run_sample`/`run_samples` in `pipeline.py`, or rewire the console script
+to use them and bring them up to date. Pick one source of truth.
+
+---
+
+## 2. `find-insertions` does not emit a GFF compatible with RelocaTE2
+
+**Symptom.** `find-insertions` writes only
+`<outdir>/results/<target>.<te_name>.all_nonref_insert.txt` (custom
+tab-separated columns). RelocaTE2 wrote
+`<outdir>/repeat/results/ALL.all_nonref_insert.gff` as well, with the
+attribute set:
+
+```
+ID=repeat_<chrom>_<start>_<end>;Name=<TE>;TSD=<TSD>;Note=...;
+Right_junction_reads=<N>;Left_junction_reads=<N>;
+Right_support_reads=<N>;Left_support_reads=<N>;
+```
+
+`characterize` does emit a GFF, but with a different schema
+(`avg_flankers=`, `spanners=`, `type=`, `TE=`, `TSD=`) and only after step
+7. There is currently **no RelocaTE3 step that produces the pre-genotyped,
+RelocaTE2-compatible non-reference-insertion GFF**.
+
+**Why this matters.**
+- The validation pipeline's `normalize_relocate3.py` had to parse the
+  custom `.txt` instead of a GFF. Anyone downstream (workflow engines,
+  comparison scripts, mPing-tracking tools the lab already runs) expecting
+  the RelocaTE2 layout will need a similar shim.
+- The legacy schema is what the field has standardized on and what the
+  bundled `validation_data/real_rice/relocate2_results/*/repeat/results/ALL.all_nonref_insert.gff`
+  uses for the regression baseline.
+
+**Suggested fix.** Have `find-insertions` also write a parallel
+`<outdir>/results/<target>.<te_name>.all_nonref_insert.gff` in the
+RelocaTE2 attribute schema (the data is already computed — see
+`_write_event_start` in `insertions.py`, which has `right_count`,
+`left_count`, `top_tsd`, `te_orient`, `repeat_family`). Adding the GFF
+writer next to the existing TXT writer is mechanical.
+
+---
+
+## 3. `find-insertions --tsd` is required and global
+
+**Symptom.** The `find-insertions` subcommand requires `--tsd MOTIF`
+(e.g. `TTA`). Help text reads: `"TSD-unknown mode is not yet supported"`.
+
+**Why this matters.**
+- The legacy `ALL.all_nonref_insert.gff` includes per-call TSDs like `TAA`,
+  `TTA`, `TGA`, `insufficient_data` — that's because mPing junctions in
+  real data don't all share one motif. Requiring a single global motif
+  means RelocaTE3 will either reject or mislabel non-canonical TSDs.
+- A run can only handle one TE family per invocation. The legacy
+  pipeline could batch TE libraries.
+
+**Suggested fix.** Implement TSD auto-detection from the bracketing reads,
+already half-supported by the dominant-TSD selection logic in
+`_write_event_start`. At minimum, allow `--tsd auto` to pick per-cluster
+TSDs and treat overlap-less or ambiguous calls as `insufficient_data`
+(matching the RelocaTE2 label).
+
+---
+
+## 4. Subcommand naming: `run` does only map + trim
+
+**Symptom.** `relocaTE3 run` chains `map` + `trim` and stops. Producing
+insertion calls requires the user to also chain `align-genome` →
+`find-insertions` (and optionally `characterize`) by hand.
+
+**Why this matters.** Most users will read "run" as "run the pipeline."
+A new collaborator setting up a single-sample test will assume `run`
+suffices and be surprised when no insertion table appears. (This is
+exactly what I did before reading the help carefully.)
+
+**Suggested fix.** One of:
+- Rename `run` → `run-trim` (or `map-trim`) so the partial scope is
+  explicit, and add a new `pipeline` / `all` subcommand that runs every
+  step end-to-end.
+- Or keep `run` but extend it to chain through `find-insertions` when the
+  required inputs (`--genome`, `--reference-ins`, etc.) are supplied.
+
+---
+
+## 5. No single-deliverable entry point for one sample
+
+**Symptom.** Producing the per-sample `all_nonref_insert` file requires
+four CLI calls (`index-genome`, `run`, `align-genome`, `find-insertions`),
+each with their own paths to thread through. The bundled
+`validation/real_rice/run_relocate3.sh` exists almost entirely to glue
+these together for one sample.
+
+**Why this matters.** Same usability concern as #4. Workflow engines
+(Nextflow / Snakemake) like the step granularity; humans running a quick
+test do not.
+
+**Suggested fix.** Tied to #4 — a `pipeline` subcommand whose flags are
+just `--left/--right/--te-library/--genome/--reference-ins/--name/
+--outdir/--tsd/--threads` and which orchestrates all four internally.
+Would let the validation script collapse to a single `relocaTE3 pipeline
+...` call per sample.
+
+---
+
+## 6. `characterize` GFF schema diverges from `find-insertions` output
+
+**Symptom.** `characterize` writes
+`<stem>.characTErized.gff` with attributes
+`ID=<chrom>.<pos>.spanners;avg_flankers=...;spanners=...;type=...;TE=...;TSD=...`,
+while `find-insertions` (if/when it gets a GFF — see #2) would naturally
+want to use the RelocaTE2 attribute set. Tools reading both for the same
+sample will see two different schemas.
+
+**Suggested fix.** Once #2 is done, extend the same attribute set in
+`characterize` (keep `avg_flankers`, `spanners`, `type` but add the
+`Left_/Right_junction_reads` and `Note=` fields the legacy tools expect).
+
+---
+
+## 7. `pipeline.py` provenance helpers reference a nonexistent module API
+
+**Symptom.** `src/RelocaTE3/pipeline.py` imports
+`from RelocaTE3.align import Aligner` (fine) but also
+`from RelocaTE3.genome_align import align_to_genome, read_read_repeat` and
+`from RelocaTE3.insertions import find_insertions, write_insertions_gff,
+write_insertions_txt` — none of those module-level symbols exist in the
+current codebase (the modules expose classes `Aligner`, `InsertionFinder`,
+etc., not module-level functions of those names).
+
+**Why this matters.** `import RelocaTE3.pipeline` will raise
+`ImportError` at import time, so anything that touches the module breaks.
+Tied to #1: this whole file appears to be leftover from a previous API
+design.
+
+**Suggested fix.** Delete the file or port it to the current
+class-based API.
+
+---
+
+## 8. `map` step appears to be racy when the output dir is concurrently mutated
+
+**Symptom.** During a local `pixi run validate-rice --local --force B_10`
+run, the `map` step produced `B_10.right.bam` (667 KB, indexed OK) but
+failed with:
+
+```
+[E::hts_open_format] Failed to open file "<outdir>/B_10.left.bam" : No such file or directory
+samtools index: failed to open "<outdir>/B_10.left.bam": No such file or directory
+RelocaTE3 ERROR Command '['samtools', 'index', '.../B_10.left.bam']' returned non-zero exit status 1.
+```
+
+i.e. the left-direction BAM was either never written or was removed before
+`samtools index` ran on it, while the right-direction BAM came through fine.
+
+**Why this matters.** The trim/find-insertions steps require BOTH 5'/3'
+flanking FASTQs, so a half-map failure silently breaks the downstream
+pipeline.
+
+**Suggested investigation.** Look at `src/RelocaTE3/align.py`
+(`map_minimap_library` / its direction loop) for:
+- Whether the two directions write through a temp path that could collide.
+- Whether the indexing step assumes the previous step's output without
+  verifying.
+- Whether the failure should abort the whole `map` step or be retried.
+
+A repro should be straightforward by running `relocaTE3 run -l R1 -r R2 -T
+te.fa -n NAME -o OUT --threads N` against the rice validation FASTQs and
+watching whether one direction races the other.
+
+---
+
+## 9. `find-insertions` writes the `--target` filter value into the chromosome column
+
+**Severity.** High — it silently destroys the chromosome of every insertion
+in the output file. Any downstream comparison keyed on chromosome (the
+real-rice validation pipeline, any RelocaTE2-compat tooling) sees zero
+overlap with the legacy calls because every RelocaTE3 row's "chrom" is the
+string `"ALL"` (or whatever was passed to `--target`).
+
+**Symptom.** Raw output at
+`<outdir>/results/<target>.<te_name>.all_nonref_insert.txt` has the literal
+target value in column 4 instead of the chromosome:
+
+```
+mPing  TTA        B_10  ALL  1041521..1041523  + T:2 R:1 L:1 ST:0 SR:0 SL:0
+mPing  singleton  B_10  ALL  1623995..1623997  - T:1 R:1 L:0 ST:0 SR:0 SL:0
+```
+
+Reproduced on `B_10` from the real-rice validation set:
+- R2 calls: 650 mPing insertions, `chrom ∈ {Chr1..Chr12}`.
+- R3 calls: 617 mPing insertions, `chrom = "ALL"` on every row.
+- `compare_calls.py` matches on `(chrom, te_name)` → 0 shared even though
+  the call counts (650 vs 617) are within ~5% of each other and the actual
+  coordinates almost certainly do overlap heavily.
+
+**Root cause.** `src/RelocaTE3/insertions.py:421` in `_write_event_start`:
+
+```python
+out.write(
+    f"{repeat_family}\t{tsd_field}\t{sample}\t{target}\t{coor_start}..{coor}\t"
+    f"{te_orient}\tT:{total_count}\tR:{right_count}\tL:{left_count}\t"
+    f"ST:0\tSR:0\tSL:0\n"
+)
+```
+
+`target` is the CLI `--target` *filter* (`"ALL"` or a single chromosome
+name), not the cluster's actual chromosome. The actual chromosome IS
+tracked by `cluster_chrom: dict[int, str]` (built at
+`insertions.py:91` and populated at `insertions.py:191` with
+`cluster_chrom[count] = chro`), and `cluster_chrom` is even passed into
+`_write_output` (insertions.py:358) — it just isn't threaded into
+`_write_event_start`, so the row ends up using the filter as a stand-in
+for chrom.
+
+**Fix.**
+
+1. Thread the chromosome into the writer:
+   - In `InsertionFinder._write_output` (around `insertions.py:350`),
+     look up `cluster_chrom[event]` for each event and pass it to
+     `_write_event_start` as a new `chrom` argument.
+   - In `InsertionFinder._write_event_start`, replace `{target}` in the
+     f-string at line 421 with `{chrom}`. Drop the `target` parameter
+     from `_write_event_start` if it's no longer used.
+
+2. Sanity check after the fix:
+   - Re-run `relocaTE3 find-insertions ... --target ALL` on `B_10`; the
+     4th column should now be `Chr1`/`Chr2`/... .
+   - Re-run `relocaTE3 find-insertions ... --target Chr10`; the filter
+     should still restrict to Chr10 clusters but the output should now
+     literally print `Chr10` per row (it already did, but for the wrong
+     reason — verify it still does post-fix).
+
+3. Once #2 (RelocaTE2-compatible GFF) is implemented, make sure the GFF
+   writer uses the same `chrom` lookup, not `target`.
+
+**Why we are fixing this.**
+- The real-rice validation pipeline (`validation/real_rice/`) cannot
+  measure recall, precision, or Jaccard against the legacy RelocaTE2
+  baseline until R3's chrom column is correct. Right now shared=0 by
+  construction.
+- Any user running `--target ALL` (the most common case — whole-genome
+  insertion scan) gets output that's effectively unusable without
+  reprocessing the BAM.
+- The bug is cheap to fix and has no behavioral knock-on: `cluster_chrom`
+  is already populated correctly, we're only changing what gets written.
+
+**Notes for the future debugging session.**
+- Tests: `tests/` does not currently assert the chrom column value of the
+  `all_nonref_insert.txt` writer; add a regression test that runs
+  `find-insertions --target ALL` against a tiny synthetic BAM with reads
+  on at least two different reference contigs, then asserts the output
+  has both contig names in column 4 (and no `"ALL"` rows).
+- Related code locations:
+  - `src/RelocaTE3/insertions.py:91` — `cluster_chrom` declared.
+  - `src/RelocaTE3/insertions.py:191` — `cluster_chrom[count] = chro` is
+    where the real chromosome is recorded.
+  - `src/RelocaTE3/insertions.py:354..374` — `_write_output` signature
+    + call into `_write_event_start`.
+  - `src/RelocaTE3/insertions.py:376..424` — `_write_event_start` body.
+- After fixing, `validation/real_rice/normalize_relocate3.py` requires
+  no change — it already reads column 4 as `chrom`. Just re-run
+  `pixi run validate-rice --skip-run` to regenerate
+  `report/relocate3_calls.tsv` and the comparison.
+- This is independent of issue #2 (no RelocaTE2-compatible GFF emitted).
+  Fix #9 first; #2 can re-use the same `chrom` plumbing when a GFF
+  writer is added.
+
+---
+
+## Lower priority observations
+
+- `relocaTE3` always prints a `pixi` netfs-redirect WARN at startup
+  (rattler cache redirected to `$SCRATCH`). Not a RelocaTE3 bug — it's
+  pixi telling us to set `[cache.repodata]` or `PIXI_CACHE_DIR`. Worth
+  documenting in `README.md`/pixi config so SLURM logs don't include the
+  noise on every run.
+- `align-genome` writes `<name>.repeat.minimap.sorted.bam` — the literal
+  string `repeat` is hardcoded. If a user wants to track multiple TE
+  families in one project they'll get filename collisions. Possibly a
+  knob to add.
+- `relocaTE3 --version` and `relocaTE3 -V` both work, but the global
+  `--verbose` flag exists only on subcommands (via `_add_common_args`)
+  rather than the top-level parser, so `relocaTE3 -v <cmd>` errors. Minor.
+
+---
+
+## What was NOT a RelocaTE3 bug
+
+Recording these so a future debugger doesn't re-investigate them:
+
+- `ModuleNotFoundError: No module named '_config'` inside a SLURM job —
+  that was the validation script using `BASH_SOURCE[0]` to find
+  `_config.py`. Under `sbatch`, the script is copied to
+  `/var/spool/slurmd/...`. Fix lives in
+  `validation/real_rice/run_relocate3.sh`: anchor on the config path's
+  directory instead.
+- `relocaTE3: command not found` on compute nodes — pixi env not
+  inherited by SLURM jobs. Fix lives in the same script: re-exec via
+  `pixi run --manifest-path <pixi.toml> -- bash $0 "$@"` when the binary
+  isn't already on PATH.
+- The first round of "wrong flags" — I trusted `src/RelocaTE3/cli.py`
+  rather than `__main__.py`. See item #1.

--- a/pixi.lock
+++ b/pixi.lock
@@ -77,6 +77,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/0f/e7f1ff3a1cabc6c4486a7ee1b0506aedf2f5f8329760ac1f4e8032feef2b/pysam-0.24.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl
@@ -86,8 +87,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       osx-64:
       - conda: https://conda.anaconda.org/bioconda/osx-64/bedtools-2.31.1-hbb299f0_3.tar.bz2
@@ -148,6 +151,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl
@@ -157,8 +161,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/bioconda/osx-arm64/bedtools-2.31.1-he85ad4a_3.tar.bz2
@@ -218,6 +224,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl
@@ -226,10 +233,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/c1/37f2fcccce3f1494147e46ccc04996226defe9ccae8251a9ce61296fa599/pysam-0.24.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/bioconda/linux-64/bedtools-2.31.1-h13024bc_3.tar.bz2
@@ -1944,7 +1953,7 @@ packages:
   - biopython>=1.81
   - pybedtools
   - pysam
-  requires_python: '>=3.7'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
   name: docutils
   version: 0.22.4
@@ -2034,6 +2043,17 @@ packages:
   - types-docutils ; extra == 'lint'
   - sphinx>=5 ; extra == 'standalone'
   - pytest ; extra == 'test'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+  name: pluggy
+  version: 1.6.0
+  sha256: e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+  requires_dist:
+  - pre-commit ; extra == 'dev'
+  - tox ; extra == 'dev'
+  - pytest ; extra == 'testing'
+  - pytest-benchmark ; extra == 'testing'
+  - coverage ; extra == 'testing'
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/55/0f/e7f1ff3a1cabc6c4486a7ee1b0506aedf2f5f8329760ac1f4e8032feef2b/pysam-0.24.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: pysam
@@ -2128,6 +2148,26 @@ packages:
   - pysocks>=1.5.6,!=1.5.7,<2.0 ; extra == 'socks'
   - backports-zstd>=1.0.0 ; python_full_version < '3.14' and extra == 'zstd'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
+  name: pytest
+  version: 9.1.0
+  sha256: 8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32
+  requires_dist:
+  - colorama>=0.4 ; sys_platform == 'win32'
+  - exceptiongroup>=1 ; python_full_version < '3.11'
+  - iniconfig>=1.0.1
+  - packaging>=22
+  - pluggy>=1.5,<2
+  - pygments>=2.7.2
+  - tomli>=1 ; python_full_version < '3.11'
+  - argcomplete ; extra == 'dev'
+  - attrs>=19.2 ; extra == 'dev'
+  - hypothesis>=3.56 ; extra == 'dev'
+  - mock ; extra == 'dev'
+  - requests ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  - xmlschema ; extra == 'dev'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/98/c1/37f2fcccce3f1494147e46ccc04996226defe9ccae8251a9ce61296fa599/pysam-0.24.0-cp312-cp312-macosx_11_0_arm64.whl
   name: pysam
   version: 0.24.0
@@ -2159,6 +2199,11 @@ packages:
   - flake8 ; extra == 'test'
   - mypy ; extra == 'test'
   requires_python: '>=3.5'
+- pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
+  name: iniconfig
+  version: 2.3.0
+  sha256: f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
   name: pygments
   version: 2.20.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -17,6 +17,7 @@ pip = ">=26.1.2,<27"
 [pypi-dependencies]
 RelocaTE3 = { path = ".", editable = true }
 sphinx = ">=7.0"
+pytest = ">=9.0.3,<10"
 
 [tasks]
 test = "pytest -ra -q"

--- a/src/RelocaTE3/insertions.py
+++ b/src/RelocaTE3/insertions.py
@@ -161,6 +161,7 @@ class InsertionFinder:
             rnames = bam.references
             bin_ins = [0]
             count = 0
+            prev_chro: str | None = None
             for record in bam.fetch(reference=ref, until_eof=True):
                 if record.is_unmapped:
                     continue
@@ -172,6 +173,13 @@ class InsertionFinder:
                 seq = record.query_sequence or ""
                 chro = rnames[record.reference_id]
                 strand = "-" if record.is_reverse else "+"
+
+                # Force a new cluster when the chromosome changes so that
+                # cluster_chrom is never overwritten and clusters don't span
+                # contigs that share a coordinate range.
+                if prev_chro is not None and chro != prev_chro:
+                    count += 1
+                    bin_ins = [start, end]
 
                 bin_ins, count = self._assign_cluster(
                     bin_ins,
@@ -189,6 +197,7 @@ class InsertionFinder:
                     te_insertions_reads,
                 )
                 cluster_chrom[count] = chro
+                prev_chro = chro
         finally:
             bam.close()
 
@@ -360,13 +369,14 @@ class InsertionFinder:
         """Write the ``all_nonref_insert`` table consumed by characterize (step 7)."""
         with open(out_txt, "w") as out:
             for event in sorted(te_insertions, key=int):
+                chrom = cluster_chrom.get(event, target)
                 for tsd_start in sorted(te_insertions[event], key=int):
                     self._write_event_start(
                         out,
                         event,
                         tsd_start,
                         sample,
-                        target,
+                        chrom,
                         read_repeat,
                         te_insertions,
                         te_insertions_reads,
@@ -379,7 +389,7 @@ class InsertionFinder:
         event,
         tsd_start,
         sample,
-        target,
+        chrom,
         read_repeat,
         te_insertions,
         te_insertions_reads,
@@ -418,7 +428,7 @@ class InsertionFinder:
             tsd_field = "supporting_junction"
 
         out.write(
-            f"{repeat_family}\t{tsd_field}\t{sample}\t{target}\t{coor_start}..{coor}\t"
+            f"{repeat_family}\t{tsd_field}\t{sample}\t{chrom}\t{coor_start}..{coor}\t"
             f"{te_orient}\tT:{total_count}\tR:{right_count}\tL:{left_count}\t"
             f"ST:0\tSR:0\tSL:0\n"
         )

--- a/tests/insertions_test.py
+++ b/tests/insertions_test.py
@@ -65,19 +65,33 @@ class TestGenomeAlign(unittest.TestCase):
 
 
 def _write_junction_bam(bam_path, contig, length, reads):
-    """Build a sorted, indexed BAM of simple junction reads."""
+    """Build a sorted, indexed BAM of simple junction reads on one contig."""
+    return _write_multi_contig_bam(bam_path, [(contig, length)], reads)
+
+
+def _write_multi_contig_bam(bam_path, contigs, reads):
+    """Build a sorted, indexed BAM across one or more contigs.
+
+    Args:
+        bam_path: output BAM path.
+        contigs: list of (name, length) tuples; index in this list is the
+            reference_id used by each read spec via the ``ref`` key (default 0).
+        reads: list of read specs. Each must include ``name``, ``seq``,
+            ``start0``; may include ``ref`` (contig index), ``flag``, ``mapq``,
+            ``nm``.
+    """
     header = {
         "HD": {"VN": "1.6", "SO": "coordinate"},
-        "SQ": [{"SN": contig, "LN": length}],
+        "SQ": [{"SN": name, "LN": length} for name, length in contigs],
     }
-    reads = sorted(reads, key=lambda r: r["start0"])
+    reads = sorted(reads, key=lambda r: (r.get("ref", 0), r["start0"]))
     with pysam.AlignmentFile(bam_path, "wb", header=header) as out:
         for spec in reads:
             seg = pysam.AlignedSegment(out.header)
             seg.query_name = spec["name"]
             seg.query_sequence = spec["seq"]
             seg.flag = spec.get("flag", 0)
-            seg.reference_id = 0
+            seg.reference_id = spec.get("ref", 0)
             seg.reference_start = spec["start0"]
             seg.mapping_quality = spec.get("mapq", 60)
             seg.cigarstring = f"{len(spec['seq'])}M"
@@ -126,6 +140,65 @@ class TestInsertionFinder(unittest.TestCase):
             self.assertEqual(cols[6], "T:2")
             self.assertEqual(cols[7], "R:1")
             self.assertEqual(cols[8], "L:1")
+
+    def test_target_all_preserves_per_cluster_chrom(self):
+        """With --target ALL, the chrom column must be the cluster's real chrom, not 'ALL'."""
+        with tempfile.TemporaryDirectory() as workdir:
+            bam_path = os.path.join(workdir, "flank.bam")
+            # Two independent insertion sites on two different chromosomes,
+            # each with a left + right junction sharing tsd_start.
+            reads = [
+                # Chr1 site at tsd_start=1000
+                {
+                    "name": "rL1:end:5",
+                    "seq": "A" * 37 + "TTA",
+                    "start0": 962,
+                    "ref": 0,
+                },
+                {
+                    "name": "rR1:start:5",
+                    "seq": "TTA" + "A" * 37,
+                    "start0": 999,
+                    "ref": 0,
+                },
+                # Chr2 site at tsd_start=2000
+                {
+                    "name": "rL2:end:5",
+                    "seq": "A" * 37 + "TTA",
+                    "start0": 1962,
+                    "ref": 1,
+                },
+                {
+                    "name": "rR2:start:5",
+                    "seq": "TTA" + "A" * 37,
+                    "start0": 1999,
+                    "ref": 1,
+                },
+            ]
+            _write_multi_contig_bam(
+                bam_path, [("Chr1", 5000), ("Chr2", 5000)], reads
+            )
+
+            read_repeat = os.path.join(workdir, "read_repeat_name.txt")
+            with open(read_repeat, "w") as fh:
+                for n in ("rL1", "rR1", "rL2", "rR2"):
+                    fh.write(f"{n}\tmping\t+\n")
+
+            finder = InsertionFinder(mismatch_allow=0, min_mapq=1)
+            out_txt = finder.find_insertions(
+                bam_file=Path(bam_path),
+                read_repeat_file=Path(read_repeat),
+                tsd="TTA",
+                target="ALL",
+                sample="HEG4",
+                outdir=Path(workdir),
+            )
+            rows = [ln for ln in out_txt.read_text().splitlines() if ln.strip()]
+            self.assertEqual(len(rows), 2)
+            chroms = sorted(r.split("\t")[3] for r in rows)
+            self.assertEqual(chroms, ["Chr1", "Chr2"])
+            for r in rows:
+                self.assertNotEqual(r.split("\t")[3], "ALL")
 
     def test_tsd_unknown_raises(self):
         with tempfile.TemporaryDirectory() as workdir:


### PR DESCRIPTION
## Summary

This fixes a bug where `find-insertions --target ALL` wrote the target filter value (`ALL`) into the chromosome column of `all_nonref_insert.txt` instead of the actual chromosome for each insertion cluster.

This caused downstream validation against RelocaTE2 to report zero overlap because all RelocaTE3 calls appeared to be on chromosome `ALL`.

## Changes

- Thread the per-cluster chromosome into the insertion output writer.
- Write the actual cluster chromosome in column 4 of `all_nonref_insert.txt`.
- Add regression coverage for `--target ALL`.
- Add `pytest` to the Pixi environment for running tests.

## Validation

Tested against the real-rice validation pipeline. After the fix, RelocaTE3 output uses chromosome names such as `Chr1`, `Chr2`, etc., instead of `ALL`.