### PR TITLE
docs: make all agent direction reflect the single cli.py entry point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,16 @@ the full pipeline), `annotate-ref`, `index-genome`, `align-genome`,
 delegates to `cli.main` (`raise SystemExit(main())`, so `python -m` propagates
 the CLI's exit code). Don't put logic there.
 
+**Access points (use these, in order):** the installed console script
+`relocaTE3` (regenerated from the `RelocaTE3.cli:main` entry point on
+install/reinstall); `python -m RelocaTE3`; or, in tests/library code,
+`from RelocaTE3.cli import main`. All three reach the *same* `cli.main`.
+
+**Anti-regression:** there is exactly **one** CLI module (`cli.py`). Never
+reintroduce a second parser/front-end or move `main` out of `cli.py`. A past
+`__main__.py`-vs-`cli.py` split silently diverged and caused wrong-file edits and
+two null-result validation runs.
+
 If you add or rename a subcommand, edit `cli.py` and update the README
 subcommand table + `docs/source/usage.rst`. The acceptance test imports library
 functions directly, so it does not catch CLI drift — the subprocess smoke tests

--- a/notes/potential_issues_2026-06-16.md
+++ b/notes/potential_issues_2026-06-16.md
@@ -12,6 +12,15 @@ items here are RelocaTE3 issues to consider fixing in a future session.
 
 ## 1. `src/RelocaTE3/cli.py` and parts of `src/RelocaTE3/pipeline.py` are dead code
 
+> **RESOLVED / OUTDATED (2026-07-11) — do not act on the description below.** The
+> two CLI front-ends were consolidated (PR #19) and the canonical CLI was then
+> relocated into `cli.py`. **Current reality is the opposite of what this item
+> says:** `src/RelocaTE3/cli.py` is now the *single canonical CLI*, the console
+> entry point is `relocaTE3 = "RelocaTE3.cli:main"`, and `src/RelocaTE3/__main__.py`
+> is a thin `python -m` launcher. The subcommands/flags an agent should trust are
+> the ones in `cli.py` (see `AGENTS.md` → "The CLI lives in one file"). Text kept
+> for historical record only.
+
 **Symptom.** `cli.py` registers subcommands (`run`, `find-insertions`,
 `find-reference`, `characterize`) with a *different* CLI shape than what
 the installed `relocaTE3` binary actually exposes. For example, `cli.py`'s

--- a/plans/2026-06-19-characterize-validation-design.md
+++ b/plans/2026-06-19-characterize-validation-design.md
@@ -4,6 +4,10 @@
 **Scope:** `RelocaTE3/validation/real_rice/` (with one small upstream change in
 `src/RelocaTE3/characterize.py` to support CRAM input).
 **Status:** Approved; ready for implementation per Section 9 order.
+
+> **Note (2026-07-11):** references below to `__main__.py` as "the registered entry
+> point" / two CLI front-ends are historical. The CLI now lives in `cli.py` (entry
+> point `RelocaTE3.cli:main`); `__main__.py` is a thin launcher. See `AGENTS.md`.
 **Update 2026-06-19:** CRAM support has landed upstream in
 `src/RelocaTE3/characterize.py` (`_open_alignment` detects `.cram` by suffix
 and passes `reference_filename`; `Characterizer.characterize` takes a

--- a/plans/2026-07-10-cli-consolidation-design.md
+++ b/plans/2026-07-10-cli-consolidation-design.md
@@ -1,5 +1,11 @@
 # CLI Consolidation Design — `__main__.py` + `cli.py`
 
+> **SHIPPED then SUPERSEDED (2026-07-11).** This design made `__main__.py` canonical
+> and `cli.py` a shim (PR #19). The CLI was then relocated: **`cli.py` is now the
+> canonical module, `__main__.py` is a thin launcher, entry point
+> `RelocaTE3.cli:main`** (see `plans/2026-07-10-cli-canonical-relocation-plan.md` and
+> `AGENTS.md`). Read this doc as history.
+
 Date: 2026-07-10
 Author: Nathan Mathieu (with Claude Code)
 Status: design — awaiting review (not yet committed or implemented)

--- a/plans/2026-07-10-cli-consolidation-plan.md
+++ b/plans/2026-07-10-cli-consolidation-plan.md
@@ -1,5 +1,10 @@
 # CLI Consolidation Implementation Plan
 
+> **SUPERSEDED (2026-07-11):** This plan made `__main__.py` canonical and `cli.py` a
+> shim. The CLI has since been relocated — **`cli.py` is now canonical, `__main__.py`
+> is a thin launcher, entry point `RelocaTE3.cli:main`** (see
+> `plans/2026-07-10-cli-canonical-relocation-plan.md` and `AGENTS.md`). History only.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Collapse the two divergent argparse front-ends into one — `__main__.py` stays the canonical, validated CLI and `cli.py` becomes a compatibility shim — without changing any installed `__main__.py` command behavior.

--- a/plans/PERFORMANCE.md
+++ b/plans/PERFORMANCE.md
@@ -105,6 +105,15 @@ The 551 low-flanker (avg_flankers < 2) R3-only calls need a second look. Some ar
 
 ## Priority 4: two-CLI-file consolidation
 
+> **COMPLETED (2026-07-11).** Shipped in two steps: consolidation (PR #19) merged the
+> two front-ends, then the canonical CLI was relocated into `src/RelocaTE3/cli.py` with
+> a thin `__main__.py` launcher (Option A below is what shipped). **Current state: one
+> CLI module, `cli.py`; entry point `relocaTE3 = "RelocaTE3.cli:main"`; `python -m
+> RelocaTE3` delegates to `cli.main`.** See `AGENTS.md` → "The CLI lives in one file".
+> A follow-up remains: the dispatch cleanup (`build_parser()`, pass `Namespace` instead
+> of `**vars(parsed)`, drop per-handler `**kwargs`) — see
+> `todo/cmd-run-drops-trim-thresholds.md`. The historical analysis below is kept for record.
+
 `src/RelocaTE3/__main__.py` and `src/RelocaTE3/cli.py` have parallel implementations of the same subcommands. The registered entry point is `__main__:main`, so the harness runs through `__main__.py`; `cli.py` is documented but not wired. This has produced **two null-result SLURM runs** during recent parity work — each time I edited the wrong path (`map_reads_to_genome` instead of `map_genome_minimap`; function-based `find_insertions` instead of `InsertionFinder` class). CONTEXT.md warns about it but the warning is easy to miss.
 
 ### The right consolidation


### PR DESCRIPTION
Point every tracked doc at the current architecture (one CLI module, cli.py; entry point RelocaTE3.cli:main; __main__.py a thin python -m launcher):
- AGENTS.md: add explicit access-points list + anti-regression guard
- notes/potential_issues: RESOLVED banner on the now-inverted 'cli.py is dead code / __main__ is the entry point' item
- plans/PERFORMANCE.md: mark the two-CLI-consolidation priority COMPLETED
- dated plans: SUPERSEDED/historical banners so agents don't read stale state Also logged the decision to .living/decisions.md (local; gitignored).