### PR TITLE
Refactor CLI dispatch: extract build_parser(), Namespace dispatch, drop **kwargs

### DIFF
--- a/plans/2026-07-11-cli-dispatch-cleanup-design.md
+++ b/plans/2026-07-11-cli-dispatch-cleanup-design.md
@@ -1,0 +1,96 @@
+# CLI Dispatch Cleanup Design
+
+Date: 2026-07-11
+Author: Nathan Mathieu (with Claude Code)
+Status: approved — ready for implementation planning
+Branch: `refactor-cli-dispatch`
+
+## Purpose
+
+Modernize the internals of the single canonical CLI (`src/RelocaTE3/cli.py`)
+without changing any command behavior. Today `main()` builds the argparse tree
+inline and dispatches with `parsed.func(**vars(parsed))`, which forces every one
+of the 8 `cmd_*` handlers to end in a `**kwargs` sink (a pure smell — none of
+them read it) and to duplicate the flag list in their signatures. This is the
+"actually well-designed" follow-on to the CLI relocation.
+
+This is **branch 1 of 3** on the CLI internals: (1) this behavior-preserving
+dispatch refactor; (2) fix `cmd_run` dropping `--min-match/--min-trimmed/--mismatch`
+(behavior change, separate validation); (3) resolve `--aligner bwa` being accepted
+but unsupported. Branches 2 and 3 are OUT OF SCOPE here.
+
+## Current state (ground truth, `cli.py`)
+
+- 8 `_menu_*(parser)` builders, each ending `parser.set_defaults(func=cmd_*)`.
+- `main()` assembles the subparsers inline (≈ lines 637–724) and dispatches at
+  `parsed.func(**vars(parsed))` (≈ line 726).
+- 8 `cmd_*` handlers, each `cmd_x(a, b, …, verbose, **kwargs)`. **All 8 take
+  `**kwargs` purely to swallow `command`/`func`; none read it.**
+
+## Approach (chosen: A — Namespace dispatch)
+
+- **A (chosen)** — handlers become `cmd_x(args: argparse.Namespace)` and read
+  `args.foo`; dispatch becomes `return parsed.func(parsed)`. Conventional argparse
+  idiom (matches the old `cli.py` `_run_*(args)` handlers); no magic; each handler
+  becomes self-documenting about exactly which args it reads.
+- B — keep explicit params, drop `**kwargs`, filter `vars(parsed)` per handler via
+  `inspect.signature`. Rejected: introspection magic in the dispatcher.
+- C — dataclass per command. Rejected: YAGNI.
+
+## Design
+
+Three changes, all inside `src/RelocaTE3/cli.py`:
+
+1. **Extract `build_parser() -> argparse.ArgumentParser`.** Move the subparser
+   assembly out of `main()` into `build_parser()`. `main()` becomes: build parser
+   → `parse_args` → handle `--version` / no-args (print help) / `verbose` setup →
+   `return parsed.func(parsed)`, keeping the existing try/except (KeyboardInterrupt,
+   SystemExit, Exception) guard exactly as-is. The `prog = __entry_points__.get(...)`
+   logic stays.
+
+2. **Namespace dispatch.** `parsed.func(**vars(parsed))` → `parsed.func(parsed)`.
+   Rewrite each of the 8 `cmd_*` signatures to `cmd_x(args)` and prefix each param
+   read in the body with `args.` (mechanical; the `_menu_*` `dest` names are the
+   `args` attribute names). Remove all 8 `**kwargs` sinks.
+
+3. **No `_menu_*` / flag / default / choice changes.** Parser *definitions* are
+   untouched — only the location of `main()`'s assembly code moves.
+
+### Behavior-preserving guarantee (the crux)
+
+`cmd_run` continues to read exactly what it reads today
+(`args.left/right/te_library/name/outdir/threads/aligner/verbose`) and **still does
+not forward `--min-match/--min-trimmed/--mismatch`** to `identify_TE_reads`. The
+bug is preserved on purpose so B_10 stays byte-identical. Add an explicit guard
+comment at that call site so no reviewer/agent "helpfully" fixes it and breaks the
+gate:
+
+```python
+# BUG preserved intentionally (see todo/cmd-run-drops-trim-thresholds.md):
+# --min-match/--min-trimmed/--mismatch are parsed but not forwarded here.
+# Fixing changes trim output; do it in its own validated branch, not this refactor.
+```
+
+## Testing / validation
+
+- **All 48 existing tests stay green.** `main_test.py` monkeypatches
+  `cli.cmd_map`/`cli.cmd_characterize`; since dispatch now passes a `Namespace`
+  positionally, update the test's `mockreturn(**kwargs)` to `mockreturn(args)` and
+  assert on `args.name` / `args.left` / `args.te_library` / `args.sites_file` /
+  `args.bam` (test-only change; no product impact).
+- **Add one test:** `build_parser()` returns a parser that parses a known
+  subcommand (e.g. `build_parser().parse_args(["index-genome", "-g", "x"]).func`
+  is `cmd_index_genome`) — locks in the extraction.
+- **B_10 `--local --force` gate: byte-identical to the pre-refactor baseline**
+  (sorted normalized records + summaries + result files; recall/precision/Jaccard/
+  TSD/status unchanged). This is the proof the refactor changed nothing.
+
+## Out of scope (separate branches)
+
+- `cmd_run` threshold forwarding fix (`todo/cmd-run-drops-trim-thresholds.md`).
+- `--aligner bwa` accepted-but-unsupported (`todo/run-aligner-bwa-unsupported.md`).
+
+## Files touched
+
+- `src/RelocaTE3/cli.py` (build_parser extraction, Namespace dispatch, drop `**kwargs`)
+- `tests/main_test.py` (mock accepts a `Namespace`; add `build_parser` test)

--- a/plans/2026-07-11-cli-dispatch-cleanup-design.md
+++ b/plans/2026-07-11-cli-dispatch-cleanup-design.md
@@ -94,3 +94,21 @@ gate:
 
 - `src/RelocaTE3/cli.py` (build_parser extraction, Namespace dispatch, drop `**kwargs`)
 - `tests/main_test.py` (mock accepts a `Namespace`; add `build_parser` test)
+
+## Result (2026-07-11)
+
+**PASS — post-refactor B_10 output byte-identical to baseline.** Ran on compute
+node (SLURM alloc, `--threads 8`).
+
+- `pixi run test`: 49 passed (48 + the new `test_build_parser_registers_subcommand`);
+  ruff clean, zero F821.
+- B_10 `--local --force` before vs. after: all 14 normalized report `.tsv` files,
+  both `summary.txt` reports, and all three
+  `results/ALL.mping.all_nonref_insert{,.characTErized}.{txt,gff}` files identical
+  after sorting; same output file set. Metrics unchanged (non-ref Recall 0.9662 /
+  Precision 0.9101 / Jaccard 0.8820; characterized Recall 0.9843 / Precision 0.8882
+  / Jaccard 0.8758; TSD 555/564; Status 554/564).
+
+Shipped as: `refactor(cli): extract build_parser() from main()` + `refactor(cli):
+dispatch Namespace to cmd_* handlers; drop **kwargs sinks`. `cmd_run` threshold
+bug and `--aligner bwa` remain deferred (separate branches).

--- a/plans/2026-07-11-cli-dispatch-cleanup-plan.md
+++ b/plans/2026-07-11-cli-dispatch-cleanup-plan.md
@@ -1,0 +1,242 @@
+# CLI Dispatch Cleanup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Modernize `src/RelocaTE3/cli.py` internals — extract `build_parser()`, dispatch by passing the `Namespace`, and drop the 8 `**kwargs` sinks — with zero command-behavior change.
+
+**Architecture:** Three edits inside `cli.py`: (1) move `main()`'s inline subparser assembly into `build_parser()`; (2) change `parsed.func(**vars(parsed))` → `return parsed.func(parsed)`; (3) convert each `cmd_x(a, b, …, **kwargs)` to `cmd_x(args)` reading `args.foo`. The `cmd_run` threshold bug is preserved on purpose (documented) so B_10 stays byte-identical. Behavior-preserving refactor only; the `cmd_run` and `bwa` fixes are separate branches.
+
+**Tech Stack:** Python 3.10+, argparse, pytest, pixi, ruff (F821 undefined-name is the safety net for missed `args.` prefixes).
+
+**Design doc:** `plans/2026-07-11-cli-dispatch-cleanup-design.md` (approved).
+
+**Reference skills:** @superpowers:executing-plans to drive; @superpowers:test-driven-development discipline (keep the 48-test suite green across each task).
+
+---
+
+## Task 0: Capture the B_10 baseline (before any edit)
+
+**Files:** none modified.
+
+**Step 1:** `pixi run test` → record (expect 48 passed).
+**Step 2:** Resolve harness dirs (from repo root):
+```bash
+cd validation/real_rice && CONFIG="config.toml"
+python3 -c "from _config import load_config; c=load_config('$CONFIG'); print(c['paths']['relocate3_outdir']); print(c['paths']['report_dir'])"; cd -
+```
+**Step 3:** `pixi run validate-rice --local --force B_10`
+**Step 4:** Copy baseline OUT of the validation tree:
+```bash
+BASE=<scratchpad>/cli-dispatch-baseline; mkdir -p "$BASE"
+cp -r validation/real_rice/report "$BASE/report"
+cp -r validation/real_rice/results/B_10/results "$BASE/B_10_results"
+```
+(Use the session scratchpad dir for `<scratchpad>`.)
+
+---
+
+## Task 1: Extract `build_parser()` (behavior-identical; dispatch unchanged)
+
+**Files:** Modify `src/RelocaTE3/cli.py`; Test `tests/main_test.py`.
+
+**Step 1: Write the failing test** — add to `tests/main_test.py`:
+```python
+def test_build_parser_registers_subcommand():
+    """build_parser() returns a parser whose subcommands dispatch to cmd_*."""
+    from RelocaTE3.cli import build_parser, cmd_index_genome
+
+    parsed = build_parser().parse_args(["index-genome", "-g", "ref.fa"])
+    assert parsed.func is cmd_index_genome
+```
+
+**Step 2: Run — expect FAIL** (`ImportError: cannot import name 'build_parser'`):
+`pixi run pytest tests/main_test.py::test_build_parser_registers_subcommand -v`
+
+**Step 3: Implement** — in `src/RelocaTE3/cli.py`, add a `build_parser()` function (place it directly above `main()`) containing the parser + subparser assembly currently inside `main()` (the block from `parser = argparse.ArgumentParser(...)` through the last `_menu_characterize(...)` call, i.e. current lines ~629–710):
+```python
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the top-level parser with all subcommands."""
+    prog = __entry_points__.get(__name__, "relocaTE3")
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        formatter_class=CustomHelpFormatter,
+        description=main.__doc__,
+        epilog=f"Written by {__author__}",
+    )
+    parser.add_argument("-V", "--version", action="version", version=__version__)
+    subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
+    subparsers.required = True
+    # ... move the 8 _menu_*(subparsers.add_parser(...)) blocks here VERBATIM ...
+    return parser
+```
+Then rewrite `main()` to call it, keeping the try/except and dispatch EXACTLY as they are for now:
+```python
+def main(args: list[str] | None = None) -> int:
+    """Tool for identifying Transposable transposition from WGS data by comparison to a reference genome."""
+    parser = build_parser()
+
+    try:
+        cli_args = args or sys.argv[1:]
+        if not cli_args:
+            parser.print_help(sys.stderr)
+            raise SystemExit(0)
+        parsed = parser.parse_args(cli_args)
+        if getattr(parsed, "verbose", False):
+            logger.setLevel("DEBUG")
+            for handler in logger.handlers:
+                handler.setLevel("DEBUG")
+            logger.debug("Debug mode enabled.")
+        parsed.func(**vars(parsed))          # UNCHANGED in this task
+    except KeyboardInterrupt:
+        logger.warning("Terminated by user.")
+        return 1
+    except SystemExit as err:
+        if err.code != 0:
+            logger.error(err)
+            return 1
+    except Exception as err:
+        logger.error(err)
+        return 1
+    return 0
+```
+(`build_parser` references `main.__doc__` at call time, so `main` being defined below it is fine.)
+
+**Step 4: Run — expect PASS**, and the whole suite green:
+`pixi run pytest tests/main_test.py::test_build_parser_registers_subcommand -v` then `pixi run test` (48 + 1 = 49 passed).
+
+**Step 5: Verify wiring unchanged:** `pixi run relocaTE3 --help` (8 subcommands, prog `relocaTE3`); `pixi run relocaTE3 run --help` (same flags).
+
+**Step 6: Ruff** — `~/.local/bin/ruff check src/RelocaTE3/cli.py` → clean.
+
+**Step 7: Commit**
+```bash
+git add src/RelocaTE3/cli.py tests/main_test.py
+git commit -m "refactor(cli): extract build_parser() from main()"
+```
+
+---
+
+## Task 2: Namespace dispatch + convert all 8 handlers (drop **kwargs)
+
+**Files:** Modify `src/RelocaTE3/cli.py`, `tests/main_test.py`.
+
+Dispatch and handler signatures MUST change together (dispatch passes the Namespace positionally, so handlers must accept one positional).
+
+**Step 1: Change dispatch** in `main()`: `parsed.func(**vars(parsed))` → `return parsed.func(parsed)`. Keep the trailing `return 0` (it still handles the no-args/`--help` `SystemExit(0)` fall-through). Behavior identical because every handler returns 0.
+
+**Step 2: Convert every `cmd_*` handler.** For each of the 8 handlers (`cmd_map`, `cmd_trim`, `cmd_run`, `cmd_characterize`, `cmd_annotate_ref`, `cmd_index_genome`, `cmd_align_genome`, `cmd_find_insertions`): change the signature to `def cmd_x(args) -> int:` and prefix every former-parameter reference in the body with `args.`. Delete the `**kwargs`. Bodies are otherwise unchanged.
+
+Worked example — `cmd_index_genome` (smallest):
+```python
+# BEFORE
+def cmd_index_genome(genome_fasta, force, verbose, **kwargs) -> int:
+    """..."""
+    from RelocaTE3.align import Aligner
+    aln = Aligner()
+    aln.verbose = bool(verbose)
+    aln.index_genome(genome_fasta, force=force)
+    logger.info("Indexed genome %s", genome_fasta)
+    return 0
+# AFTER
+def cmd_index_genome(args) -> int:
+    """..."""
+    from RelocaTE3.align import Aligner
+    aln = Aligner()
+    aln.verbose = bool(args.verbose)
+    aln.index_genome(args.genome_fasta, force=args.force)
+    logger.info("Indexed genome %s", args.genome_fasta)
+    return 0
+```
+
+Worked example — `cmd_run` (ADD the bug-preservation comment):
+```python
+def cmd_run(args) -> int:
+    """Identify TE-containing reads and generate flanking reads (map + trim).
+
+    Maps reads to the TE library then trims the TE-matching portion. This is
+    steps 2-3 (TE-read identification and flank generation), not the complete
+    insertion-calling pipeline.
+    """
+    from RelocaTE3.librelocate import RelocaTE
+    from RelocaTE3.ReadLibrary import ReadLibrary
+
+    fileset = [args.left] + ([args.right] if args.right else [])
+    reads = ReadLibrary(fileset, args.name)
+    out = Path(args.outdir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    relocate = RelocaTE(TElib=args.te_library, threads=args.threads, verbose=int(args.verbose))
+    # BUG preserved intentionally (see todo/cmd-run-drops-trim-thresholds.md):
+    # args.minimum_match_length / minimum_trimmed_length / mismatch_allowance are
+    # parsed but NOT forwarded to identify_TE_reads. Fixing changes trim output;
+    # do it in its own validated branch, not this refactor.
+    n = relocate.identify_TE_reads(reads, out, search_tool=args.aligner)
+    logger.info("%d read(s) written", n)
+    return 0
+```
+
+Apply the same mechanical transform to the remaining 6. The `dest` names (= `args.` attribute names) come from each `_menu_*`; e.g. `cmd_characterize` reads `args.sites_file`, `args.bam`, `args.genome_fasta`, `args.outdir`, `args.excision`, `args.samtools`, `args.bcftools`, `args.verbose`.
+
+**Step 3: Update `tests/main_test.py` mock** to receive a `Namespace`:
+```python
+def mockreturn(args):
+    """Stand-in command handler that records its Namespace and succeeds."""
+    mockreturn.args = args
+    return 0
+```
+and update the assertions in the two tests that use it:
+```python
+# test_main_map
+assert mockreturn.args.name == "HEG4"
+assert mockreturn.args.left == "r1.fq"
+assert mockreturn.args.te_library == "te.fa"
+# test_main_characterize
+assert mockreturn.args.sites_file == "sites.txt"
+assert mockreturn.args.bam == ["a.bam", "b.bam"]
+```
+(The `monkeypatch.setattr(cli, "cmd_map"/"cmd_characterize", mockreturn)` targets are already correct.)
+
+**Step 4: Run the suite** — `pixi run test` → all pass (49). The monkeypatched tests confirm `map`/`characterize` dispatch a Namespace; `test_run_cli_generates_flanking_reads` and the acceptance test exercise real handler bodies.
+
+**Step 5: Ruff F821 gate (critical).** Several CLI handler bodies (`align-genome`, `find-insertions`, `annotate-ref`, `map`, `trim`) are NOT run by pytest — only by B_10. A missed `args.` prefix becomes an undefined name. Run:
+`~/.local/bin/ruff check src/RelocaTE3/cli.py`
+Expected: **All checks passed** — in particular ZERO `F821 undefined name`. If ruff reports F821 for a bare param name, you missed an `args.` prefix — fix it. Also `~/.local/bin/ruff format --check src/RelocaTE3/cli.py`.
+
+**Step 6: Manual entry smoke** for a handler pytest doesn't cover, to catch a NameError ruff might miss:
+`pixi run relocaTE3 index-genome --help` and `pixi run relocaTE3 align-genome --help` (parse OK), and confirm `pixi run relocaTE3 --version` works.
+
+**Step 7: Commit**
+```bash
+git add src/RelocaTE3/cli.py tests/main_test.py
+git commit -m "refactor(cli): dispatch Namespace to cmd_* handlers; drop **kwargs sinks"
+```
+
+---
+
+## Task 3: B_10 byte-identical validation gate
+
+**Files:** none modified.
+
+**Step 1:** `pixi run test` green (49); `~/.local/bin/ruff check src/RelocaTE3/cli.py` clean.
+**Step 2:** `pixi run validate-rice --local --force B_10`
+**Step 3:** Compare sorted normalized records against the Task-0 baseline (NOT checksums):
+```bash
+BASE=<scratchpad>/cli-dispatch-baseline
+for f in $(cd "$BASE/report" && find . -name '*.tsv'); do
+  diff <(sort "$BASE/report/$f") <(sort "validation/real_rice/report/$f") >/dev/null && echo "OK $f" || echo "DIFF $f"
+done
+diff "$BASE/report/nonref/summary.txt" validation/real_rice/report/nonref/summary.txt
+diff "$BASE/report/characterized/summary.txt" validation/real_rice/report/characterized/summary.txt
+for f in "$BASE"/B_10_results/*; do b=$(basename "$f"); diff <(sort "$f") <(sort "validation/real_rice/results/B_10/results/$b") >/dev/null && echo "OK $b" || echo "DIFF $b"; done
+```
+Expected: every file OK / identical; recall/precision/Jaccard/TSD/status unchanged. **Any diff is a regression** — stop and fix.
+**Step 4:** Append the result to the design doc and commit.
+
+---
+
+## Done criteria
+
+- `cli.py` has `build_parser()`; `main()` dispatches `return parsed.func(parsed)`; all 8 handlers are `cmd_x(args)` with no `**kwargs`.
+- `cmd_run` still drops the trim thresholds, with the guard comment.
+- `pixi run test` green (49); ruff clean (no F821); B_10 byte-identical.
+- `cmd_run` + `bwa` fixes remain unstarted (separate branches).

--- a/src/RelocaTE3/cli.py
+++ b/src/RelocaTE3/cli.py
@@ -622,8 +622,8 @@ def cmd_find_insertions(
 # ---------------------------------------------------------------------------
 
 
-def main(args: list[str] | None = None) -> int:
-    """Tool for identifying Transposable transposition from WGS data by comparison to a reference genome."""
+def build_parser() -> argparse.ArgumentParser:
+    """Build the top-level argument parser with all subcommands registered."""
     prog = __entry_points__.get(__name__, "relocaTE3")
 
     parser = argparse.ArgumentParser(
@@ -708,6 +708,13 @@ def main(args: list[str] | None = None) -> int:
             "genome-aligned BAM files, classifying each site by zygosity and excision status.",
         )
     )
+
+    return parser
+
+
+def main(args: list[str] | None = None) -> int:
+    """Tool for identifying Transposable transposition from WGS data by comparison to a reference genome."""
+    parser = build_parser()
 
     try:
         cli_args = args or sys.argv[1:]

--- a/src/RelocaTE3/cli.py
+++ b/src/RelocaTE3/cli.py
@@ -416,69 +416,45 @@ def _menu_find_insertions(parser: argparse.ArgumentParser) -> argparse.ArgumentP
 # ---------------------------------------------------------------------------
 
 
-def cmd_map(
-    left, right, te_library, name, outdir, threads, aligner, verbose, **kwargs
-) -> int:
+def cmd_map(args: argparse.Namespace) -> int:
     """Align reads to TE library and write BAM files."""
     from RelocaTE3.align import Aligner
     from RelocaTE3.ReadLibrary import ReadLibrary
 
-    fileset = [left] + ([right] if right else [])
-    reads = ReadLibrary(fileset, name)
-    out = Path(outdir)
+    fileset = [args.left] + ([args.right] if args.right else [])
+    reads = ReadLibrary(fileset, args.name)
+    out = Path(args.outdir)
     out.mkdir(parents=True, exist_ok=True)
 
-    aln = Aligner(threads=threads, default_aligner=aligner)
-    bamfiles = aln.map_minimap_library(reads, out, te_library)
-    logger.info("%d BAM file(s) written to %s", len(bamfiles), outdir)
+    aln = Aligner(threads=args.threads, default_aligner=args.aligner)
+    bamfiles = aln.map_minimap_library(reads, out, args.te_library)
+    logger.info("%d BAM file(s) written to %s", len(bamfiles), args.outdir)
     return 0
 
 
-def cmd_trim(
-    bam,
-    name,
-    minimum_match_length,
-    minimum_trimmed_length,
-    mismatch_allowance,
-    outdir,
-    verbose,
-    **kwargs,
-) -> int:
+def cmd_trim(args: argparse.Namespace) -> int:
     """Trim TE sequence from TE-library BAM reads and emit junction-named flanking FASTQs."""
     from RelocaTE3.librelocate import RelocaTE
 
-    bam_paths = [Path(b) for b in bam]
-    out = Path(outdir)
+    bam_paths = [Path(b) for b in args.bam]
+    out = Path(args.outdir)
     out.mkdir(parents=True, exist_ok=True)
 
-    relocate = RelocaTE(verbose=int(verbose))
+    relocate = RelocaTE(verbose=int(args.verbose))
     directions = relocate._bam_directions(bam_paths)
     flank_written = relocate.write_trimmed_reads(
-        name,
+        args.name,
         list(zip(directions, bam_paths)),
         out,
-        minimum_match_length=minimum_match_length,
-        minimum_trimmed_length=minimum_trimmed_length,
-        mismatch_allowance=mismatch_allowance,
+        minimum_match_length=args.minimum_match_length,
+        minimum_trimmed_length=args.minimum_trimmed_length,
+        mismatch_allowance=args.mismatch_allowance,
     )
     logger.info("Wrote %d flanking read(s) to %s", flank_written, out / "flanking")
     return 0
 
 
-def cmd_run(
-    left,
-    right,
-    te_library,
-    name,
-    outdir,
-    threads,
-    aligner,
-    minimum_match_length,
-    minimum_trimmed_length,
-    mismatch_allowance,
-    verbose,
-    **kwargs,
-) -> int:
+def cmd_run(args: argparse.Namespace) -> int:
     """Identify TE-containing reads and generate flanking reads (map + trim).
 
     Maps reads to the TE library then trims the TE-matching portion. This is
@@ -488,130 +464,104 @@ def cmd_run(
     from RelocaTE3.librelocate import RelocaTE
     from RelocaTE3.ReadLibrary import ReadLibrary
 
-    fileset = [left] + ([right] if right else [])
-    reads = ReadLibrary(fileset, name)
-    out = Path(outdir)
+    fileset = [args.left] + ([args.right] if args.right else [])
+    reads = ReadLibrary(fileset, args.name)
+    out = Path(args.outdir)
     out.mkdir(parents=True, exist_ok=True)
 
-    relocate = RelocaTE(TElib=te_library, threads=threads, verbose=int(verbose))
-    n = relocate.identify_TE_reads(reads, out, search_tool=aligner)
+    relocate = RelocaTE(
+        TElib=args.te_library, threads=args.threads, verbose=int(args.verbose)
+    )
+    # BUG preserved intentionally (see plans/2026-07-11-cli-dispatch-cleanup-design.md,
+    # "Out of scope"): args.minimum_match_length / minimum_trimmed_length /
+    # mismatch_allowance are parsed but NOT forwarded to identify_TE_reads. Fixing
+    # changes trim output; do it in its own validated branch, not this refactor.
+    n = relocate.identify_TE_reads(reads, out, search_tool=args.aligner)
     logger.info("%d read(s) written", n)
     return 0
 
 
-def cmd_characterize(
-    sites_file,
-    bam,
-    genome_fasta,
-    outdir,
-    excision,
-    samtools,
-    bcftools,
-    verbose,
-    **kwargs,
-) -> int:
+def cmd_characterize(args: argparse.Namespace) -> int:
     """Characterize insertion sites as homozygous, heterozygous, somatic or excised."""
     from RelocaTE3.characterize import Characterizer
 
     characterizer = Characterizer(
-        samtools=samtools, bcftools=bcftools, verbose=int(verbose)
+        samtools=args.samtools, bcftools=args.bcftools, verbose=int(args.verbose)
     )
-    bam_paths = [Path(b) for b in bam]
+    bam_paths = [Path(b) for b in args.bam]
     txt_path, gff_path = characterizer.characterize(
-        sites_file=Path(sites_file),
+        sites_file=Path(args.sites_file),
         bam_files=bam_paths,
-        genome_fasta=Path(genome_fasta) if genome_fasta else None,
-        outdir=Path(outdir) if outdir else None,
-        excision=excision,
+        genome_fasta=Path(args.genome_fasta) if args.genome_fasta else None,
+        outdir=Path(args.outdir) if args.outdir else None,
+        excision=args.excision,
     )
     logger.info("Characterization written to %s and %s", txt_path, gff_path)
     return 0
 
 
-def cmd_annotate_ref(
-    te_library,
-    genome_fasta,
-    outdir,
-    threads,
-    min_identity,
-    min_coverage,
-    verbose,
-    **kwargs,
-) -> int:
+def cmd_annotate_ref(args: argparse.Namespace) -> int:
     """Annotate existing/reference TE copies in the genome with minimap2 (step 0)."""
     from RelocaTE3.reference_te import ReferenceTEAnnotator
 
-    annotator = ReferenceTEAnnotator(threads=threads, verbose=int(verbose))
+    annotator = ReferenceTEAnnotator(threads=args.threads, verbose=int(args.verbose))
     bed = annotator.annotate_minimap(
-        te_library=Path(te_library),
-        genome_fasta=Path(genome_fasta),
-        outdir=Path(outdir),
-        min_identity=min_identity,
-        min_coverage=min_coverage,
+        te_library=Path(args.te_library),
+        genome_fasta=Path(args.genome_fasta),
+        outdir=Path(args.outdir),
+        min_identity=args.min_identity,
+        min_coverage=args.min_coverage,
     )
     logger.info("Existing-TE annotation written to %s", bed)
     return 0
 
 
-def cmd_index_genome(genome_fasta, force, verbose, **kwargs) -> int:
+def cmd_index_genome(args: argparse.Namespace) -> int:
     """Index/format the reference genome (samtools faidx + minimap2 index) (step 1)."""
     from RelocaTE3.align import Aligner
 
     aln = Aligner()
-    aln.verbose = bool(verbose)
-    aln.index_genome(genome_fasta, force=force)
-    logger.info("Indexed genome %s", genome_fasta)
+    aln.verbose = bool(args.verbose)
+    aln.index_genome(args.genome_fasta, force=args.force)
+    logger.info("Indexed genome %s", args.genome_fasta)
     return 0
 
 
-def cmd_align_genome(
-    genome_fasta, fastq, name, outdir, paired, threads, verbose, **kwargs
-) -> int:
+def cmd_align_genome(args: argparse.Namespace) -> int:
     """Align trimmed flanking reads to the reference genome (step 4)."""
     from RelocaTE3.align import Aligner
 
-    aln = Aligner(threads=threads)
-    aln.verbose = bool(verbose)
+    aln = Aligner(threads=args.threads)
+    aln.verbose = bool(args.verbose)
     bam = aln.map_genome_minimap(
-        genome=genome_fasta,
-        fastqs=fastq,
-        name=name,
-        outdir=outdir,
-        paired=paired,
+        genome=args.genome_fasta,
+        fastqs=args.fastq,
+        name=args.name,
+        outdir=args.outdir,
+        paired=args.paired,
     )
     logger.info("Genome-aligned BAM written to %s", bam)
     return 0
 
 
-def cmd_find_insertions(
-    bam,
-    read_repeat,
-    tsd,
-    target,
-    name,
-    outdir,
-    te_name,
-    reference_ins,
-    mismatch_allow,
-    min_mapq,
-    verbose,
-    **kwargs,
-) -> int:
+def cmd_find_insertions(args: argparse.Namespace) -> int:
     """Find non-reference insertions from genome-aligned flanking reads (step 5)."""
     from RelocaTE3.insertions import InsertionFinder
 
     finder = InsertionFinder(
-        mismatch_allow=mismatch_allow, min_mapq=min_mapq, verbose=int(verbose)
+        mismatch_allow=args.mismatch_allow,
+        min_mapq=args.min_mapq,
+        verbose=int(args.verbose),
     )
     out_txt = finder.find_insertions(
-        bam_file=Path(bam),
-        read_repeat_file=Path(read_repeat),
-        tsd=tsd,
-        target=target,
-        sample=name,
-        outdir=Path(outdir),
-        te_name=te_name,
-        reference_ins=Path(reference_ins) if reference_ins else None,
+        bam_file=Path(args.bam),
+        read_repeat_file=Path(args.read_repeat),
+        tsd=args.tsd,
+        target=args.target,
+        sample=args.name,
+        outdir=Path(args.outdir),
+        te_name=args.te_name,
+        reference_ins=Path(args.reference_ins) if args.reference_ins else None,
     )
     logger.info("Non-reference insertions written to %s", out_txt)
     return 0
@@ -730,7 +680,7 @@ def main(args: list[str] | None = None) -> int:
                 handler.setLevel("DEBUG")
             logger.debug("Debug mode enabled.")
 
-        parsed.func(**vars(parsed))
+        return parsed.func(parsed)
 
     except KeyboardInterrupt:
         logger.warning("Terminated by user.")

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -12,9 +12,9 @@ from RelocaTE3 import __version__, cli
 from RelocaTE3.cli import main
 
 
-def mockreturn(**kwargs):
-    """Stand-in command handler that records its arguments and succeeds."""
-    mockreturn.kwargs = kwargs
+def mockreturn(args):
+    """Stand-in command handler that records its Namespace and succeeds."""
+    mockreturn.args = args
     return 0
 
 
@@ -28,9 +28,9 @@ def test_main_version(capsys: pytest.CaptureFixture):
 def test_main_map(monkeypatch: Generator):
     monkeypatch.setattr(cli, "cmd_map", mockreturn)
     assert main(["map", "-l", "r1.fq", "-T", "te.fa", "-n", "HEG4"]) == 0
-    assert mockreturn.kwargs["name"] == "HEG4"
-    assert mockreturn.kwargs["left"] == "r1.fq"
-    assert mockreturn.kwargs["te_library"] == "te.fa"
+    assert mockreturn.args.name == "HEG4"
+    assert mockreturn.args.left == "r1.fq"
+    assert mockreturn.args.te_library == "te.fa"
 
 
 def test_main_map_verbose(monkeypatch: Generator, caplog: pytest.LogCaptureFixture):
@@ -44,8 +44,8 @@ def test_main_map_verbose(monkeypatch: Generator, caplog: pytest.LogCaptureFixtu
 def test_main_characterize(monkeypatch: Generator):
     monkeypatch.setattr(cli, "cmd_characterize", mockreturn)
     assert main(["characterize", "-s", "sites.txt", "-b", "a.bam", "b.bam"]) == 0
-    assert mockreturn.kwargs["sites_file"] == "sites.txt"
-    assert mockreturn.kwargs["bam"] == ["a.bam", "b.bam"]
+    assert mockreturn.args.sites_file == "sites.txt"
+    assert mockreturn.args.bam == ["a.bam", "b.bam"]
 
 
 def test_module_entry_point_version():

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -68,3 +68,11 @@ def test_console_script_version():
     proc = subprocess.run(["relocaTE3", "--version"], capture_output=True, text=True)
     assert proc.returncode == 0
     assert proc.stdout.strip()
+
+
+def test_build_parser_registers_subcommand():
+    """build_parser() returns a parser whose subcommands dispatch to cmd_*."""
+    from RelocaTE3.cli import build_parser, cmd_index_genome
+
+    parsed = build_parser().parse_args(["index-genome", "-g", "ref.fa"])
+    assert parsed.func is cmd_index_genome


### PR DESCRIPTION
## Summary

Modernize the internals of the single canonical CLI (`src/RelocaTE3/cli.py`) — a
behavior-preserving refactor, no command behavior changes.

- **Extract `build_parser()`** from `main()`, so the parser is constructed in one
  cohesive function and `main()` is a thin parse→dispatch shim.
- **Namespace dispatch:** replace `parsed.func(**vars(parsed))` with
  `return parsed.func(parsed)`, and convert all 8 `cmd_*` handlers from
  `cmd_x(a, b, …, **kwargs)` to `cmd_x(args: argparse.Namespace)` reading
  `args.foo`. Removes all 8 `**kwargs` sinks (a pure smell — none were read) and
  the signature/flag duplication.

## Behavior preservation

Parser definitions (`_menu_*`, flags, defaults, choices) are untouched — only
where `main()`'s assembly lives moved. Each handler reads exactly the same
argument set it declared before. The known `cmd_run` bug (parses
`--min-match/--min-trimmed/--mismatch` but doesn't forward them to
`identify_TE_reads`) is **intentionally preserved and documented** so this
refactor stays byte-identical; the fix is deferred to its own validated branch.

Minor side effect: `python -m`/console dispatch now propagates the handler's exit
code (previously discarded, always 0). All handlers return 0 today, so it's
exit-identical — just honest plumbing.

## Validation

- `pixi run test`: **49 passed** (48 + new `test_build_parser_registers_subcommand`);
  ruff clean, zero F821.
- **B_10 real-rice `--local --force` before vs. after: byte-identical** — all 14
  normalized report TSVs, both summaries, and all result files identical after
  sorting; recall/precision/Jaccard/TSD/status unchanged (non-ref Recall 0.9662 /
  Precision 0.9101 / Jaccard 0.8820; characterized TSD 555/564, Status 554/564).

## Out of scope (follow-up branches)

- Fix `cmd_run` dropping the three trim thresholds (behavior change → own validation).
- Resolve `run --aligner bwa` being accepted by argparse but rejected by
  `identify_TE_reads` (implement or drop from `choices`).

Design/plan: `plans/2026-07-11-cli-dispatch-cleanup-{design,plan}.md`.