### PR TITLE
fix(aligners): bowtie2 TE-library mapping must use --local to keep junction reads

### DIFF
--- a/src/RelocaTE3/aligners.py
+++ b/src/RelocaTE3/aligners.py
@@ -259,7 +259,15 @@ class Bowtie2Backend(AlignerBackend):
     def map_te_library(
         self, reads, te_library, outdir, *, threads=None, tmpdir=None
     ) -> list[Path]:
-        """Map each read side to the TE library (SE, -k 20 to keep multi-mappers)."""
+        """Map each read side to the TE library (SE, -k 20 to keep multi-mappers).
+
+        Uses ``--local`` so bowtie2 soft-clips TE-junction reads (part TE, part
+        genomic flank) instead of dropping them: in the default end-to-end mode a
+        read must align over its full length, so junction reads -- the ones that
+        carry the non-reference insertion signal -- align 0 times and no flank is
+        recovered. ``--local`` matches the soft-clipping behavior of the bwa-mem
+        and minimap2 backends.
+        """
         threads = self._threads(threads)
         self.index(te_library)
         read_set = {"left": reads.left()}
@@ -270,7 +278,11 @@ class Bowtie2Backend(AlignerBackend):
             for side, read_file in read_set.items():
                 out_bam = Path(outdir) / f"{reads.name}.{side}.bam"
                 self._run(
-                    te_library, ["-k", "20", "-U", str(read_file)], out_bam, threads, td
+                    te_library,
+                    ["-k", "20", "--local", "-U", str(read_file)],
+                    out_bam,
+                    threads,
+                    td,
                 )
                 bams.append(out_bam)
         return bams

--- a/tests/aligners_test.py
+++ b/tests/aligners_test.py
@@ -124,6 +124,61 @@ class TestBackendContract(unittest.TestCase):
                 aln.map_genome(telib, [tefq], d / "x.bam")
 
 
+class TestBowtie2JunctionSoftclip(unittest.TestCase):
+    """Regression: bowtie2 TE-library mapping must soft-clip junction reads.
+
+    A TE-junction read is part TE, part genomic flank -- exactly the reads that
+    carry the non-reference insertion signal. In bowtie2's default end-to-end
+    mode such a read must align over its full length, so the foreign flank half
+    makes it align 0 times and no soft-clipped flank is recovered (find-insertions
+    then returns nothing). ``Bowtie2Backend.map_te_library`` passes ``--local`` so
+    bowtie2 soft-clips the flank and keeps the read, matching the bwa-mem and
+    minimap2 backends. This test fails if ``--local`` is dropped: the junction
+    reads stop aligning and no soft-clipped alignment is produced.
+
+    (The ``TestBackendContract`` bowtie2 case uses reads wholly inside the TE,
+    which align end-to-end, so it does not exercise this path.)
+    """
+
+    @unittest.skipUnless(_available("bowtie2"), "bowtie2 not available")
+    def test_te_mapping_softclips_junction_reads(self):
+        te = REF[500:1000]  # 500 bp TE
+        flank = _refseq(n=500, seed=99)  # independent foreign flank
+        # Junction reads: 40 bp TE + 40 bp foreign flank, in both orientations.
+        reads = []
+        for i in range(1, 6):
+            te_chunk = te[100 + i * 20 : 100 + i * 20 + 40]
+            fl_chunk = flank[i * 20 : i * 20 + 40]
+            reads.append((f"j{i}_5", te_chunk + fl_chunk))  # TE then flank
+            reads.append((f"j{i}_3", fl_chunk + te_chunk))  # flank then TE
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            telib = d / "te.fa"
+            _write_fa(telib, {"teA": te})
+            tefq = d / "junction.fq"
+            _write_fq(tefq, reads)
+            rl = ReadLibrary([str(tefq)], "S1")
+            aln = get_aligner("bowtie2", threads=1)
+            bams = aln.map_te_library(rl, telib, d, threads=1)
+            mapped = 0
+            softclipped = 0
+            with pysam.AlignmentFile(str(bams[0]), "rb") as fh:
+                for rec in fh.fetch(until_eof=True):
+                    if rec.is_unmapped:
+                        continue
+                    mapped += 1
+                    if any(op == 4 for op, _ in (rec.cigartuples or [])):
+                        softclipped += 1
+            self.assertGreater(
+                mapped, 0, "no junction reads aligned (end-to-end regression?)"
+            )
+            self.assertGreater(
+                softclipped,
+                0,
+                "no soft-clipped junction alignments (bowtie2 needs --local)",
+            )
+
+
 class TestPslToSam(unittest.TestCase):
     """The PSL->SAM converter (BLAT backend) tested without the blat binary."""
 


### PR DESCRIPTION
## Summary

`Bowtie2Backend.map_te_library` mapped reads to the TE library in bowtie2's
default **end-to-end** mode, which requires a read to align over its full length.
TE-junction reads — part TE, part genomic flank — are exactly the reads that
carry the non-reference insertion signal, and they cannot align end-to-end to the
TE library. So they aligned 0 times, produced no soft-clipped flank, and
`find-insertions` returned **0 non-reference insertions on every sample** whenever
`--te-aligner bowtie2` was used.

The bwa-mem and minimap2 backends soft-clip by default, so they capture junction
reads and work correctly. This is a bowtie2-backend-specific defect: bowtie2 is
advertised as a supported TE aligner but was silently non-functional (it ran to
completion and reported empty results rather than erroring).

## Fix

Add `--local` to the bowtie2 **TE-library** mapping so it soft-clips junction
reads, matching the bwa-mem / minimap2 semantics. One-line change in
`map_te_library`'s alignment invocation, plus an expanded docstring.

## Evidence

Measured on a 500k-read subset vs the mPing TE librar

| aligner (as RT3 invokes it)      | aligned | soft-clipped (junction reads) |
|----------------------------------|--------:|------------------------------:|
| `bwa mem -a`                     |     559 |
| `bowtie2 -k20` (end-to-end, old) |     353 |
| `bowtie2 -k20 --local` (new)     |     559 |                           276 |

Whole-sample insertion tables: bwa/minimap2 ≈ 295–468
**0 rows** for every sample before the fix. `--local`
and makes bowtie2 behave like bwa.

## Tests

Adds `tests/aligners_test.py::TestBowtie2JunctionSoft
part-TE/part-flank junction reads through `Bowtie2Bac
asserts they align **with a soft-clip** (CIGAR `S`).
regression test: it **fails** with `--local` removed
reproducing the empty-table symptom) and **passes** with the fix. Full
`aligners_test.py` suite is green (blat skipped where

## Scope / notes

- Only the **TE-library** stage is changed. `map_geno
  aligner) still uses end-to-end; that path is not ex
  `relocate3-bowtie2-bwa` benchmark variant (which us
  and its flanking-read inputs are already TE-trimmed. If bowtie2 is ever used as
  the genome aligner, that stage should be reviewed f
- Separate, known issue (not addressed here): `Bowtie
  `BwaBackend.index` do an unlocked check-then-build
  race under concurrency. The relocate-benchmark work
  indexes serially before fan-out; a file lock or per-invocation index dir would
  fix it upstream.

## Downstream

After merge, relocate-benchmark will re-pin `callers/
new rev, re-enable `relocate3-bowtie2-bwa` in its con