### PR TITLE
feat(tsd): wire variable-length UNK inference into find_insertions

### DIFF
--- a/src/RelocaTE3/cli.py
+++ b/src/RelocaTE3/cli.py
@@ -383,7 +383,7 @@ def _menu_find_insertions(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     parser.add_argument(
         "--tsd",
         required=True,
-        help="TSD motif (e.g. TTA); TSD-unknown mode is not yet supported",
+        help="TSD motif (e.g. TTA), fixed wildcard (e.g. ...), or UNK to infer each TSD",
     )
     parser.add_argument(
         "-c", "--target", default="ALL", help="Chromosome to analyze, or ALL"

--- a/src/RelocaTE3/insertions.py
+++ b/src/RelocaTE3/insertions.py
@@ -69,14 +69,9 @@ class InsertionFinder:
             Path to the written ``*.all_nonref_insert.txt`` file.
         """
         if re.search(r"UNK|UKN|unknown", tsd, re.IGNORECASE):
-            # The literal "UNK" sentinel triggers R2's full depth-mode pipeline,
-            # which is not yet ported. Regex-friendly TSD patterns (e.g. "..."
-            # for a 3 bp wildcard) ARE accepted and flow through _tsd_check
-            # naturally — the captured TSD bases come from the read sequence,
-            # mirroring R2's depth-mode output on a fixed-length TSD.
-            raise NotImplementedError(
-                "TSD-unknown (read-depth) inference is not yet ported; provide a "
-                'TSD motif or a fixed-length wildcard regex (e.g. "..." for 3 bp).'
+            return self._find_insertions_unknown_tsd(
+                bam_file, read_repeat_file, target, sample, outdir, te_name,
+                reference_ins,
             )
 
         read_repeat = self._load_read_repeat(read_repeat_file)
@@ -123,6 +118,54 @@ class InsertionFinder:
             te_insertions_reads,
             cluster_chrom,
         )
+        return out_txt
+
+    def _find_insertions_unknown_tsd(
+        self,
+        bam_file: Path,
+        read_repeat_file: Path,
+        target: str,
+        sample: str,
+        outdir: Path,
+        te_name: str,
+        reference_ins: Path | None,
+    ) -> Path:
+        """Call variable-length TSDs using the RelocaTE2 ``UNK`` strategy.
+
+        The live CLI historically used only the fixed-pattern class path.  The
+        function-based path below preserves its output contract while using the
+        already ported breakpoint/depth inference helpers for each cluster.
+        """
+        read_repeat = self._load_read_repeat(read_repeat_file)
+        if reference_ins:
+            from RelocaTE3.reference_te import ReferenceTEAnnotator
+
+            existing_te = ReferenceTEAnnotator.load_existing_te(reference_ins, target)
+        else:
+            existing_te = defaultdict(lambda: {"start": {}, "end": {}})
+
+        result_dir = Path(outdir) / "results"
+        result_dir.mkdir(parents=True, exist_ok=True)
+        out_txt = result_dir / f"{target}.{te_name}.all_nonref_insert.txt"
+        with open(out_txt, "w") as out:
+            for cluster in _stream_clusters(
+                str(bam_file), read_repeat, quality_filter=self._passes_quality
+            ):
+                if target != "ALL" and cluster.chrom != target:
+                    continue
+                for ins in _call_insertions(cluster, genome=None):
+                    # Match the fixed-TSD path's reference-TE edge exclusion.
+                    edges = existing_te[cluster.chrom]
+                    if ins.end in edges["start"] or ins.start - 1 in edges["end"]:
+                        continue
+                    out.write(
+                        f"{ins.te_name}\t{ins.tsd}\t{sample}\t{ins.chrom}\t"
+                        f"{ins.start}..{ins.end}\t{ins.strand}\t"
+                        f"T:{ins.left_junction_reads + ins.right_junction_reads}\t"
+                        f"R:{ins.right_junction_reads}\tL:{ins.left_junction_reads}\t"
+                        f"ST:0\tSR:{ins.right_support_reads}\tSL:{ins.left_support_reads}\n"
+                    )
+        logger.info("Wrote variable-length TSD insertions table %s", out_txt)
         return out_txt
 
     # ------------------------------------------------------------------
@@ -574,8 +617,11 @@ def _junction_info(
 
 def _te_family(read_repeat: dict[str, tuple[str, str]], read_name: str) -> str:
     """Best-effort TE family name for a junction read."""
-    if read_name in read_repeat:
-        return read_repeat[read_name][0]
+    # The genome-aligned flank carries the junction suffix, while the trim
+    # step's read_repeat_name table is keyed by the original untagged name.
+    real_name = _JUNCTION_RE.sub("", read_name)
+    if real_name in read_repeat:
+        return read_repeat[real_name][0]
     return "NA"
 
 
@@ -602,12 +648,18 @@ class _Cluster:
         self.hi = gend if self.hi is None else max(self.hi, gend)
 
 
-def _stream_clusters(bam_path: str, read_repeat: dict[str, tuple[str, str]]):
+def _stream_clusters(
+    bam_path: str,
+    read_repeat: dict[str, tuple[str, str]],
+    quality_filter=None,
+):
     """Yield :class:`_Cluster` objects by streaming a coordinate-sorted BAM."""
     with pysam.AlignmentFile(bam_path, "rb") as bam:
         current: _Cluster | None = None
         for rec in bam.fetch(until_eof=True):
             if rec.is_unmapped:
+                continue
+            if quality_filter is not None and not quality_filter(rec):
                 continue
             chrom = bam.get_reference_name(rec.reference_id)
             gstart = rec.reference_start + 1
@@ -700,7 +752,7 @@ def _resolve_tsd(
     i_start: int,
     i_end: int,
     tsd_len: int,
-    genome: pysam.FastaFile,
+    genome: pysam.FastaFile | None,
 ) -> str:
     """Capture TSD literally from a junction read; fall back to the genome.
 
@@ -718,6 +770,8 @@ def _resolve_tsd(
         captured = _capture_tsd_from_read(obs.seq, "left", tsd_len)
         if captured:
             return captured
+    if genome is None:
+        return "UNK"
     fetched = _fetch_tsd(genome, chrom, i_start, i_end)
     return fetched or "UNK"
 
@@ -726,7 +780,7 @@ def _make_insertion(
     chrom: str,
     left_reads: list[JunctionObservation],
     right_reads: list[JunctionObservation],
-    genome: pysam.FastaFile,
+    genome: pysam.FastaFile | None,
     cluster: "_Cluster",
 ) -> Insertion:
     """Build an :class:`Insertion` from the left/right junction reads of one site.
@@ -781,7 +835,9 @@ def _make_insertion(
     )
 
 
-def _call_insertions(cluster: _Cluster, genome: pysam.FastaFile) -> list[Insertion]:
+def _call_insertions(
+    cluster: _Cluster, genome: pysam.FastaFile | None
+) -> list[Insertion]:
     """Split a cluster into one or more insertions by pairing breakpoints."""
     left = _group_by_position([j for j in cluster.junctions if j.side == "left"])
     right = _group_by_position([j for j in cluster.junctions if j.side == "right"])

--- a/tests/insertions_test.py
+++ b/tests/insertions_test.py
@@ -198,22 +198,29 @@ class TestInsertionFinder(unittest.TestCase):
             for r in rows:
                 self.assertNotEqual(r.split("\t")[3], "ALL")
 
-    def test_tsd_unknown_raises(self):
+    def test_tsd_unknown_infers_variable_length_tsd(self):
         with tempfile.TemporaryDirectory() as workdir:
             bam_path = os.path.join(workdir, "flank.bam")
+            # A 5-bp TSD at 101..105: right start=101; left end=105.
             _write_junction_bam(
                 bam_path,
                 "Chr1",
                 5000,
-                [{"name": "r:end:5", "seq": "A" * 40, "start0": 100}],
+                [
+                    {"name": "rR:start:5", "seq": "GATCA" + "A" * 35, "start0": 100},
+                    {"name": "rL:end:5", "seq": "A" * 35 + "GATCA", "start0": 65},
+                ],
             )
             rr = os.path.join(workdir, "rr.txt")
-            Path(rr).write_text("r\tmping\t+\n")
+            Path(rr).write_text("rR\tmping\t+\nrL\tmping\t+\n")
             finder = InsertionFinder()
-            with self.assertRaises(NotImplementedError):
-                finder.find_insertions(
-                    Path(bam_path), Path(rr), "UNK", "Chr1", "HEG4", Path(workdir)
-                )
+            output = finder.find_insertions(
+                Path(bam_path), Path(rr), "UNK", "Chr1", "HEG4", Path(workdir)
+            )
+            row = output.read_text().strip().split("\t")
+            self.assertEqual(row[0], "mping")
+            self.assertEqual(row[1], "GATCA")
+            self.assertEqual(row[4], "101..105")
 
     def test_offset_split_merges_to_one_call(self):
         """A wildcard-TSD 1 bp offset between the two junction sides must not


### PR DESCRIPTION
Replace the NotImplementedError UNK path in InsertionFinder.find_insertions with _find_insertions_unknown_tsd, which streams clusters and calls the ported breakpoint/depth inference (_make_insertion/_resolve_tsd) with genome=None, capturing the TSD from junction reads. Also fixes _te_family to strip the junction suffix before the read_repeat lookup (genome-aligned flanks carry the suffix), adds a quality filter hook to _stream_clusters, and updates the CLI help
+ the UNK test (raises -> infers a 5 bp TSD).

This is the wiring that gives the relocate-benchmark its variable-length TSD results (TSD-exact ~0.30 -> ~0.81). It was previously live only as an uncommitted editable-install change; committing it makes the benchmark reproducible. The residual gap to R2 (~0.81 -> ~0.98) is the separate TIR-trim issue (todo/tsd-single-sided-tir-junctions.md, plans/2026-07-23-tir-aware-trim-design.md).