### PR TITLE
fix(cli): mate-anchor flanks in the align-genome subcommand path too

### DIFF
--- a/src/RelocaTE3/cli.py
+++ b/src/RelocaTE3/cli.py
@@ -344,9 +344,28 @@ def _menu_align_genome(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     )
     parser.add_argument("-o", "--outdir", default=".", help="Output directory")
     parser.add_argument(
+        "-1",
+        "--left",
+        "--r1",
+        default=None,
+        metavar="R1",
+        help="Original left/R1 reads (FASTQ). When given (with --right), junction "
+        "flanks are aligned paired with their genomic mate so ambiguous flanks are "
+        "anchored to the true insertion (reads read_repeat from --outdir).",
+    )
+    parser.add_argument(
+        "-2",
+        "--right",
+        "--r2",
+        default=None,
+        metavar="R2",
+        help="Original right/R2 reads (FASTQ), the mate file for --left.",
+    )
+    parser.add_argument(
         "--paired",
         action="store_true",
-        help="Align the first two FASTQs as a read pair",
+        help="Align the first two FASTQs as a read pair (legacy; prefer -1/-2 for "
+        "mate-anchored flank alignment)",
     )
     parser.add_argument(
         "--genome-aligner",
@@ -546,6 +565,41 @@ def cmd_index_genome(args: argparse.Namespace) -> int:
 
 def cmd_align_genome(args: argparse.Namespace) -> int:
     """Align trimmed flanking reads to the reference genome (step 4)."""
+    if args.left:
+        # Mate-anchored path: pair each junction flank with its genomic mate so
+        # ambiguous (multi-mapping) flanks are anchored to the true insertion.
+        import tempfile
+
+        from RelocaTE3.aligners import get_aligner
+        from RelocaTE3.genome_align import (
+            align_flanks_anchored,
+            read_read_repeat,
+        )
+        from RelocaTE3.ReadLibrary import ReadLibrary
+
+        reads = ReadLibrary(
+            [args.left] + ([args.right] if args.right else []), args.name
+        )
+        outdir = Path(args.outdir)
+        rr_path = outdir / "te_containing" / f"{args.name}.read_repeat_name.txt"
+        read_repeat = read_read_repeat(rr_path) if rr_path.exists() else {}
+        suffix = "minimap" if args.genome_aligner == "minimap2" else args.genome_aligner
+        out_bam = outdir / f"{args.name}.repeat.{suffix}.sorted.bam"
+        backend = get_aligner(args.genome_aligner, args.threads)
+        backend.index(args.genome_fasta)
+        with tempfile.TemporaryDirectory() as tmp:
+            bam = align_flanks_anchored(
+                backend,
+                args.genome_fasta,
+                list(args.fastq),
+                read_repeat,
+                reads,
+                out_bam,
+                args.threads,
+                tmp,
+            )
+        logger.info("Genome-aligned BAM (mate-anchored) written to %s", bam)
+        return 0
     if args.genome_aligner == "minimap2":
         # Preserve the original minimap2 path byte-for-byte (tuned flags, paired
         # handling, and the {name}.repeat.minimap.sorted.bam output name).

--- a/src/RelocaTE3/genome_align.py
+++ b/src/RelocaTE3/genome_align.py
@@ -243,6 +243,73 @@ def _restore_pair_names(
             outb.write(rec)
 
 
+def align_flanks_anchored(
+    backend,
+    genome: str,
+    flanking_files: list[str],
+    read_repeat: dict[str, tuple[str, str]],
+    reads: ReadLibrary,
+    out_bam,
+    threads: int,
+    tmp: str,
+) -> Path:
+    """Align junction flanks to ``genome``, anchoring each ambiguous flank with
+    its genomic mate (paired-end); flanks without a mate, and extra support mates,
+    go single-end. Writes the merged coordinate-sorted BAM to ``out_bam``.
+
+    Shared by :func:`align_to_genome` (pipeline path) and the ``align-genome`` CLI
+    subcommand so both get mate-anchoring.
+    """
+    tmp_path = Path(tmp)
+    sample = reads.name
+    r1_fq = tmp_path / f"{sample}.flank_R1.fq"
+    r2_fq = tmp_path / f"{sample}.flank_R2.fq"
+    se_fq = tmp_path / f"{sample}.flank_se.fq"
+    n_pair, n_se, retag = build_flank_pairs(
+        flanking_files, read_repeat, reads, r1_fq, r2_fq, se_fq
+    )
+    # supporting mates not already aligned paired with a flank (e.g. :middle mates)
+    paired_mates = {mate for _flank, mate in retag.values()}
+    support_fq = tmp_path / f"{sample}.support.fq"
+    n_support = recover_support_mates(
+        read_repeat, reads, support_fq, exclude=paired_mates
+    )
+    logger.info(
+        "%s: %d flanks paired with mates, %d single-end flanks, %d extra support",
+        sample,
+        n_pair,
+        n_se,
+        n_support,
+    )
+
+    part_bams: list[str] = []
+    if n_pair > 0:
+        raw_bam = tmp_path / f"{sample}.paired.raw.bam"
+        backend.map_genome(
+            genome, [str(r1_fq), str(r2_fq)], str(raw_bam),
+            paired=True, threads=threads, tmpdir=tmp,
+        )
+        paired_bam = tmp_path / f"{sample}.paired.bam"
+        _restore_pair_names(raw_bam, paired_bam, retag)
+        part_bams.append(str(paired_bam))
+    se_inputs = [str(p) for p, n in ((se_fq, n_se), (support_fq, n_support)) if n > 0]
+    if se_inputs:
+        se_bam = tmp_path / f"{sample}.se.bam"
+        backend.map_genome(
+            genome, se_inputs, str(se_bam), paired=False, threads=threads, tmpdir=tmp,
+        )
+        part_bams.append(str(se_bam))
+
+    out_bam = Path(out_bam)
+    out_bam.parent.mkdir(parents=True, exist_ok=True)
+    if len(part_bams) == 1:
+        Path(part_bams[0]).replace(out_bam)
+    else:
+        pysam.merge("-f", str(out_bam), *part_bams)
+    pysam.index(str(out_bam))
+    return out_bam
+
+
 def align_to_genome(
     reads: ReadLibrary,
     genome: str,
@@ -280,64 +347,9 @@ def align_to_genome(
     fullreads_bam: Path | None = None
     outbam = genome_dir / f"{sample}.genome.bam"
     with tempfile.TemporaryDirectory() as tmp:
-        tmp_path = Path(tmp)
-        # Pair each junction flank with its genomic mate: the (usually unique) mate
-        # anchors an ambiguous flank to the true insertion instead of scattering it
-        # single-end. Flanks with no genomic mate stay single-end.
-        r1_fq = tmp_path / f"{sample}.flank_R1.fq"
-        r2_fq = tmp_path / f"{sample}.flank_R2.fq"
-        se_fq = tmp_path / f"{sample}.flank_se.fq"
-        n_pair, n_se, retag = build_flank_pairs(
-            flanking_files, read_repeat, reads, r1_fq, r2_fq, se_fq
+        align_flanks_anchored(
+            backend, genome, flanking_files, read_repeat, reads, outbam, threads, tmp
         )
-        # supporting mates not already aligned paired with a flank (e.g. :middle mates)
-        paired_mates = {mate for _flank, mate in retag.values()}
-        support_fq = tmp_path / f"{sample}.support.fq"
-        n_support = recover_support_mates(
-            read_repeat, reads, support_fq, exclude=paired_mates
-        )
-        logger.info(
-            "%s: %d flanks paired with mates, %d single-end flanks, %d extra support",
-            sample,
-            n_pair,
-            n_se,
-            n_support,
-        )
-
-        part_bams: list[str] = []
-        if n_pair > 0:
-            raw_bam = tmp_path / f"{sample}.paired.raw.bam"
-            backend.map_genome(
-                genome,
-                [str(r1_fq), str(r2_fq)],
-                str(raw_bam),
-                paired=True,
-                threads=threads,
-                tmpdir=tmp,
-            )
-            paired_bam = tmp_path / f"{sample}.paired.bam"
-            _restore_pair_names(raw_bam, paired_bam, retag)
-            part_bams.append(str(paired_bam))
-        se_inputs = [
-            str(p) for p, n in ((se_fq, n_se), (support_fq, n_support)) if n > 0
-        ]
-        if se_inputs:
-            se_bam = tmp_path / f"{sample}.se.bam"
-            backend.map_genome(
-                genome,
-                se_inputs,
-                str(se_bam),
-                paired=False,
-                threads=threads,
-                tmpdir=tmp,
-            )
-            part_bams.append(str(se_bam))
-
-        if len(part_bams) == 1:
-            Path(part_bams[0]).replace(outbam)
-        else:
-            pysam.merge("-f", str(outbam), *part_bams)
-        pysam.index(str(outbam))
 
         # full (untrimmed) junction reads for false-junction filtering
         full_fq = Path(tmp) / f"{sample}.fullreads.fq"

--- a/tests/genome_align_test.py
+++ b/tests/genome_align_test.py
@@ -157,6 +157,47 @@ def test_align_to_genome_anchors_ambiguous_flank_to_mate(tmp_path: Path):
     )
 
 
+@pytest.mark.skipif(shutil.which("bwa") is None, reason="bwa not available")
+def test_align_genome_subcommand_anchors_with_mate(tmp_path: Path):
+    """The `align-genome` CLI subcommand (used by the benchmark) must mate-anchor
+    when given the original reads (-1/-2), matching align_to_genome."""
+    from RelocaTE3.cli import main
+
+    rng = random.Random(7)
+    g = [rng.choice("ACGT") for _ in range(2200)]
+    block = "".join(rng.choice("ACGT") for _ in range(100))
+    g[500:600] = list(block)
+    g[1500:1600] = list(block)
+    anchor = "".join(g[1650:1750])
+    genome = tmp_path / "g.fa"
+    genome.write_text(f">chr1\n{''.join(g)}\n")
+
+    (tmp_path / "flanking").mkdir()
+    flank = tmp_path / "flanking" / "S.left.flankingReads.fq"
+    flank.write_text(f"@r1/1:end:5\n{block}\n+\n{'I' * 100}\n")
+    (tmp_path / "te_containing").mkdir()
+    (tmp_path / "te_containing" / "S.read_repeat_name.txt").write_text(
+        "r1/1:end:5\tmPing\t+\n"
+    )
+    r1fq = tmp_path / "reads_1.fq"
+    r2fq = tmp_path / "reads_2.fq"
+    r1fq.write_text(f"@r1/1\n{block}\n+\n{'I' * 100}\n")
+    r2fq.write_text(f"@r1/2\n{_rc(anchor)}\n+\n{'I' * 100}\n")
+
+    rc = main([
+        "align-genome", "-g", str(genome), "-f", str(flank),
+        "-n", "S", "-o", str(tmp_path), "--genome-aligner", "bwa", "--threads", "1",
+        "-1", str(r1fq), "-2", str(r2fq),
+    ])
+    assert rc == 0
+    bam = tmp_path / "S.repeat.bwa.sorted.bam"
+    with pysam.AlignmentFile(str(bam), "rb") as bf:
+        f = next((r for r in bf.fetch(until_eof=True) if r.query_name == "r1/1:end:5"), None)
+    assert f is not None and not f.is_unmapped
+    assert f.is_paired, "align-genome subcommand did not mate-anchor the flank"
+    assert f.reference_start > 1000  # anchored to the true (1500) copy
+
+
 def test_collect_junction_fullreads(tmp_path: Path):
     """Full (untrimmed) sequences are pulled only for 5'/3' junction reads."""
     reads = ReadLibrary([str(R1), str(R2)], "HEG4")


### PR DESCRIPTION
The granular CLI (relocaTE3 run/align-genome/find-insertions) that the benchmark uses bypassed the paired-flank fix, which lived only in align_to_genome (run_sample/pipeline path) -- so the benchmark saw no improvement. Extract the mate-anchoring core into align_flanks_anchored() and route cmd_align_genome through it when given the original reads (new -1/-2 args; read_repeat read from --outdir). Without -1/-2 the old single-end behavior is preserved.

Evidence (real cov30x_rep1, through the CLI align-genome + find-insertions path): UNK TSD 142 -> 86 (-39%), single-sided 142 -> 119, detections 482 -> 504. Full suite green; new test asserts the align-genome subcommand mate-anchors with -1/-2.

Downstream: relocate-benchmark run.sh must pass -1/-2 to align-genome.