### PR TITLE
fix(genome-align): move single part BAM across devices, not rename

### DIFF
--- a/src/RelocaTE3/genome_align.py
+++ b/src/RelocaTE3/genome_align.py
@@ -13,6 +13,7 @@ proximity, not by BAM proper-pair flags.
 from __future__ import annotations
 
 import re
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -303,7 +304,10 @@ def align_flanks_anchored(
     out_bam = Path(out_bam)
     out_bam.parent.mkdir(parents=True, exist_ok=True)
     if len(part_bams) == 1:
-        Path(part_bams[0]).replace(out_bam)
+        # shutil.move (not Path.replace/os.rename) so the tmp -> out_bam move
+        # works across filesystems (scratch tmp vs. network run dir): a rename
+        # across devices raises OSError EXDEV.
+        shutil.move(part_bams[0], str(out_bam))
     else:
         pysam.merge("-f", str(out_bam), *part_bams)
     pysam.index(str(out_bam))

--- a/tests/genome_align_test.py
+++ b/tests/genome_align_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import random
 import shutil
 from pathlib import Path
@@ -9,7 +10,9 @@ from pathlib import Path
 import pysam
 import pytest
 
+from RelocaTE3.aligners import get_aligner
 from RelocaTE3.genome_align import (
+    align_flanks_anchored,
     align_to_genome,
     build_flank_pairs,
     collect_junction_fullreads,
@@ -196,6 +199,49 @@ def test_align_genome_subcommand_anchors_with_mate(tmp_path: Path):
     assert f is not None and not f.is_unmapped
     assert f.is_paired, "align-genome subcommand did not mate-anchor the flank"
     assert f.reference_start > 1000  # anchored to the true (1500) copy
+
+
+@pytest.mark.skipif(shutil.which("bwa") is None, reason="bwa not available")
+def test_align_flanks_anchored_moves_single_bam_across_devices(
+    tmp_path: Path, monkeypatch
+):
+    """When only one part BAM is produced (all flanks single-end, e.g. the bwa
+    TE-aligner strips mate suffixes), the result must be moved to out_bam even
+    when tmp and out_bam are on different filesystems. Path.replace() raises
+    EXDEV across devices; align_flanks_anchored must move, not rename.
+    """
+    rng = random.Random(1)
+    genome = tmp_path / "g.fa"
+    genome.write_text(">chr1\n" + "".join(rng.choice("ACGT") for _ in range(1000)) + "\n")
+
+    flank = tmp_path / "S.left.flankingReads.fq"
+    flank.write_text("@read_500_2/1:end:5\nACGTACGTACGTACGT\n+\nIIIIIIIIIIIIIIII\n")
+    # mate ALSO matched the TE -> flank goes single-end -> exactly one part BAM
+    read_repeat = {
+        "read_500_2/1:end:5": ("mPing", "+"),
+        "read_500_2/2:start:3": ("mPing", "-"),
+    }
+    reads = ReadLibrary([str(R1), str(R2)], "S")
+
+    tmp = tmp_path / "scratch"
+    tmp.mkdir()
+    out_bam = tmp_path / "out" / "S.repeat.bwa.sorted.bam"
+
+    # Simulate a cross-device move only for the final out_bam rename.
+    real_replace = Path.replace
+
+    def _exdev(self, target):
+        if Path(target) == out_bam:
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        return real_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", _exdev)
+
+    result = align_flanks_anchored(
+        get_aligner("bwa", 1), str(genome), [str(flank)], read_repeat, reads,
+        out_bam, threads=1, tmp=str(tmp),
+    )
+    assert Path(result).exists() and Path(result).stat().st_size > 0
 
 
 def test_collect_junction_fullreads(tmp_path: Path):


### PR DESCRIPTION
align_flanks_anchored used Path.replace() to place the result when only one part BAM exists (all flanks single-end -- e.g. the bwa TE-aligner strips /1 /2 mate suffixes so nothing pairs). Path.replace is os.rename, which raises OSError EXDEV ("Invalid cross-device link") when the scratch tmpdir and the output run dir are on different filesystems, crashing the align-genome step. Use shutil.move, which falls back to copy+unlink across devices.

Test simulates the cross-device condition by making Path.replace raise EXDEV for the out_bam move.