### PR TITLE
fix(aligners): restore /1,/2 mate suffix stripped by bwa in TE stage

### DIFF
--- a/src/RelocaTE3/aligners.py
+++ b/src/RelocaTE3/aligners.py
@@ -68,6 +68,28 @@ def _concat(fastqs, dest: str) -> str:
     return dest
 
 
+def _restore_mate_suffix(bam, mate: str) -> None:
+    """Append ``/{mate}`` to read names that lack a trailing ``/1``/``/2``.
+
+    bwa mem strips a trailing mate suffix from read names; because the TE stage
+    maps each side (R1/R2) to a separate BAM, the side unambiguously fixes the
+    mate. Restoring it lets downstream flank-pairing find each junction flank's
+    genomic mate. Rewrites ``bam`` in place (coordinate order is unchanged) and
+    re-indexes. No-op for reads that already carry a mate suffix.
+    """
+    bam = Path(bam)
+    tmp = bam.with_suffix(".matefix.bam")
+    with pysam.AlignmentFile(str(bam), "rb") as inp:
+        with pysam.AlignmentFile(str(tmp), "wb", template=inp) as out:
+            for rec in inp.fetch(until_eof=True):
+                name = rec.query_name
+                if not (name.endswith("/1") or name.endswith("/2")):
+                    rec.query_name = f"{name}/{mate}"
+                out.write(rec)
+    tmp.replace(bam)
+    pysam.index(str(bam))
+
+
 class AlignerBackend(ABC):
     """One aligner binary, exposing the two RelocaTE3 alignment stages."""
 
@@ -212,6 +234,9 @@ class BwaBackend(AlignerBackend):
             for side, read_file in read_set.items():
                 out_bam = Path(outdir) / f"{reads.name}.{side}.bam"
                 self._mem(te_library, [read_file], out_bam, threads, td, extra=["-a"])
+                # bwa mem strips trailing /1,/2; restore it per side so junction
+                # flanks can later be paired with their genomic mate.
+                _restore_mate_suffix(out_bam, "1" if side == "left" else "2")
                 bams.append(out_bam)
         return bams
 

--- a/tests/aligners_test.py
+++ b/tests/aligners_test.py
@@ -124,6 +124,34 @@ class TestBackendContract(unittest.TestCase):
                 aln.map_genome(telib, [tefq], d / "x.bam")
 
 
+class TestBwaMateSuffix(unittest.TestCase):
+    """bwa mem strips a trailing /1,/2 from read names. map_te_library maps each
+    side separately (left=R1, right=R2), so it must restore the mate suffix
+    (left -> /1, right -> /2); downstream flank-pairing needs it to find each
+    junction flank's genomic mate. minimap2/bowtie2 keep the suffix natively."""
+
+    @unittest.skipUnless(_available("bwa"), "bwa not available")
+    def test_map_te_library_restores_mate_suffix(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            telib = d / "te.fa"
+            _write_fa(telib, {"teA": REF[500:1000]})
+            r1, r2 = d / "r1.fq", d / "r2.fq"
+            _write_fq(r1, [(f"t{i}/1", REF[500 + i * 20 : 500 + i * 20 + 80]) for i in range(1, 6)])
+            _write_fq(r2, [(f"t{i}/2", REF[600 + i * 20 : 600 + i * 20 + 80]) for i in range(1, 6)])
+            rl = ReadLibrary([str(r1), str(r2)], "S1")
+            aln = get_aligner("bwa", threads=1)
+            bams = {b.name: b for b in aln.map_te_library(rl, telib, d, threads=1)}
+            self.assertIn("S1.left.bam", bams)
+            self.assertIn("S1.right.bam", bams)
+            with pysam.AlignmentFile(str(bams["S1.left.bam"]), "rb") as fh:
+                left = [r.query_name for r in fh.fetch(until_eof=True)]
+            with pysam.AlignmentFile(str(bams["S1.right.bam"]), "rb") as fh:
+                right = [r.query_name for r in fh.fetch(until_eof=True)]
+            self.assertTrue(left and all(n.endswith("/1") for n in left), left)
+            self.assertTrue(right and all(n.endswith("/2") for n in right), right)
+
+
 def _revcomp(seq):
     return seq.translate(str.maketrans("ACGT", "TGCA"))[::-1]
 


### PR DESCRIPTION
BwaBackend.map_te_library maps each read side to the TE library separately (left=R1, right=R2), but bwa mem strips a trailing /1,/2 from read names. The suffix is required downstream so build_flank_pairs can pair a junction flank with its genomic mate (mate-anchoring); without it the bwa TE-aligner produced 0 paired flanks and scattered every flank single-end -> many UNK TSDs. Restore the suffix per side (left -> /1, right -> /2) via _restore_mate_suffix; the side unambiguously fixes the mate. Covers bwamem2 via inheritance. minimap2 and bowtie2 keep the suffix natively and are unaffected.

Test simulates bwa's stripping and asserts left/right BAM names end /1,/2.